### PR TITLE
seasonBar: Show season special at the end of the list.

### DIFF
--- a/src/routes/MetaDetails/VideosList/SeasonsBar/SeasonsBar.js
+++ b/src/routes/MetaDetails/VideosList/SeasonsBar/SeasonsBar.js
@@ -12,7 +12,7 @@ const SeasonsBar = ({ className, seasons, season, onSelect }) => {
     const options = React.useMemo(() => {
         return seasons.map((season) => ({
             value: String(season),
-            label: `Season ${season}`
+            label: season > 0 ? `Season ${season}` : `Specials`
         }));
     }, [seasons]);
     const selected = React.useMemo(() => {
@@ -53,7 +53,7 @@ const SeasonsBar = ({ className, seasons, season, onSelect }) => {
             </Button>
             <Multiselect
                 className={styles['seasons-popup-label-container']}
-                title={`Season ${season}`}
+                title={season > 0 ? `Season ${season}` : `Specials`}
                 options={options}
                 selected={selected}
                 onSelect={seasonOnSelect}

--- a/src/routes/MetaDetails/VideosList/VideosList.js
+++ b/src/routes/MetaDetails/VideosList/VideosList.js
@@ -25,7 +25,7 @@ const VideosList = ({ className, metaItem, season, seasonOnSelect }) => {
                     typeof season === 'number' &&
                     seasons.indexOf(season) === index;
             })
-            .sort((a, b) => a - b);
+            .sort((a, b) => (a || Number.MAX_SAFE_INTEGER) - (b || Number.MAX_SAFE_INTEGER));
     }, [videos]);
     const selectedSeason = React.useMemo(() => {
         return seasons.includes(season) ?


### PR DESCRIPTION
Specials are labeled as season '0', so this commit changes how the list
is sorted, making the season 0 go to the end of the list, and labeling
it is "Specials" instead of "Season 0".

![Screenshot from 2021-03-20 14-19-23](https://user-images.githubusercontent.com/15564640/111880503-c6478480-898a-11eb-8a16-9629007eac87.png)


Fixes: #195