### PR TITLE
urlparam exception for movies fixed

### DIFF
--- a/src/router/Router/urlParamsForPath.js
+++ b/src/router/Router/urlParamsForPath.js
@@ -2,13 +2,17 @@
 
 const urlParamsForPath = (routeConfig, path) => {
     const matches = path.match(routeConfig.regexp);
+
+    if (matches[1] === 'movie' && typeof matches[3] != 'string') {
+        matches[3] = matches[2]
+    }
+
     return routeConfig.urlParamsNames.reduce((urlParams, name, index) => {
         if (Array.isArray(matches) && typeof matches[index + 1] === 'string') {
             urlParams[name] = decodeURIComponent(matches[index + 1]);
         } else {
             urlParams[name] = null;
         }
-
         return urlParams;
     }, { path });
 };


### PR DESCRIPTION
issue #216 
router and urlparam are written such that,
urls are marched against
`/metadetails/<type>/<id>/<videoid>` this type of url,
for series, where there are multiple episodes per show, show is identified by `id` and individual episode by `videoid`
but for movies there is no episode, movie itself is video, so `id` and `videoid` is one and same,
so, `/metadetails/movie/<id>/` should give expected result, but urlparamsforpath set `videoid=null`,
that is fixed
