### PR TITLE
Better Background Color For Addon Logo on Addons Page

### DIFF
--- a/src/routes/Addons/Addon/styles.less
+++ b/src/routes/Addons/Addon/styles.less
@@ -14,7 +14,7 @@
         flex: none;
         width: 6rem;
         height: 6rem;
-        background-color: @color-surface-light5;
+        background-color: @color-background-light1;
 
         .logo {
             display: block;


### PR DESCRIPTION
Before:
<img width="519" alt="Screenshot 2022-02-04 at 16 34 11" src="https://user-images.githubusercontent.com/1777923/152546904-30a46f92-8e17-49e0-8eda-7e3f8427ef63.png">

After:
<img width="392" alt="Screenshot 2022-02-04 at 16 34 49" src="https://user-images.githubusercontent.com/1777923/152546976-a554f8c0-0121-4bb9-a077-ce4295c94b14.png">

