### PR TITLE
Fix Discover Scroll

### DIFF
--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -130,7 +130,7 @@ const Discover = ({ urlParams, queryParams }) => {
                                 </div>
                                 :
                                 discover.catalog.content.type === 'Loading' ?
-                                    <div className={styles['meta-items-container']} ref={metaItemsContainerRef}>
+                                    <div ref={metaItemsContainerRef} className={styles['meta-items-container']}>
                                         {Array(CONSTANTS.CATALOG_PAGE_SIZE).fill(null).map((_, index) => (
                                             <div key={index} className={styles['meta-item-placeholder']}>
                                                 <div className={styles['poster-container']} />
@@ -141,7 +141,7 @@ const Discover = ({ urlParams, queryParams }) => {
                                         ))}
                                     </div>
                                     :
-                                    <div className={styles['meta-items-container']} onFocusCapture={metaItemsOnFocusCapture}>
+                                    <div ref={metaItemsContainerRef} className={styles['meta-items-container']} onFocusCapture={metaItemsOnFocusCapture}>
                                         {discover.catalog.content.content.map((metaItem, index) => (
                                             <MetaItem
                                                 key={index}

--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -67,6 +67,11 @@ const Discover = ({ urlParams, queryParams }) => {
         closeAddonModal();
         setSelectedMetaItemIndex(0);
     }, [discover.selected]);
+    const metaItemsContainerRef = React.useRef();
+    React.useEffect(() => {
+        if (((discover.catalog || {}).content || {}).type === 'Loading')
+            metaItemsContainerRef.current.scrollTo(0,0);
+    }, [discover.catalog]);
     return (
         <MainNavBars className={styles['discover-container']} route={'discover'}>
             <div className={styles['discover-content']}>
@@ -124,7 +129,7 @@ const Discover = ({ urlParams, queryParams }) => {
                                 </div>
                                 :
                                 discover.catalog.content.type === 'Loading' ?
-                                    <div className={styles['meta-items-container']}>
+                                    <div className={styles['meta-items-container']} ref={metaItemsContainerRef}>
                                         {Array(CONSTANTS.CATALOG_PAGE_SIZE).fill(null).map((_, index) => (
                                             <div key={index} className={styles['meta-item-placeholder']}>
                                                 <div className={styles['poster-container']} />

--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -69,8 +69,9 @@ const Discover = ({ urlParams, queryParams }) => {
     }, [discover.selected]);
     const metaItemsContainerRef = React.useRef();
     React.useEffect(() => {
-        if (((discover.catalog || {}).content || {}).type === 'Loading')
+        if (discover.catalog?.content.type === 'Loading') {
             metaItemsContainerRef.current.scrollTo(0, 0);
+        }
     }, [discover.catalog]);
     return (
         <MainNavBars className={styles['discover-container']} route={'discover'}>

--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -70,7 +70,7 @@ const Discover = ({ urlParams, queryParams }) => {
     const metaItemsContainerRef = React.useRef();
     React.useEffect(() => {
         if (((discover.catalog || {}).content || {}).type === 'Loading')
-            metaItemsContainerRef.current.scrollTo(0,0);
+            metaItemsContainerRef.current.scrollTo(0, 0);
     }, [discover.catalog]);
     return (
         <MainNavBars className={styles['discover-container']} route={'discover'}>


### PR DESCRIPTION
The scroll of the Discover page would not go to top once a genre or page was changed.