### PR TITLE
Fix Broken Image Icon Showing for Backdrops on MetaDetails Page

### DIFF
--- a/src/routes/MetaDetails/MetaDetails.js
+++ b/src/routes/MetaDetails/MetaDetails.js
@@ -107,12 +107,7 @@ const MetaDetails = ({ urlParams, queryParams }) => {
                                         {
                                             typeof metaDetails.metaItem.content.content.background === 'string' &&
                                                 metaDetails.metaItem.content.content.background.length > 0 ?
-                                                <div className={styles['background-image-layer']}>
-                                                    <Image
-                                                        className={styles['background-image']}
-                                                        src={metaDetails.metaItem.content.content.background}
-                                                        alt={' '}
-                                                    />
+                                                <div className={styles['background-image-layer']} style={{backgroundImage:'url('+metaDetails.metaItem.content.content.background+')'}}>
                                                 </div>
                                                 :
                                                 null

--- a/src/routes/MetaDetails/styles.less
+++ b/src/routes/MetaDetails/styles.less
@@ -44,6 +44,10 @@
             bottom: 0;
             left: 0;
             z-index: -1;
+            background-repeat: no-repeat;
+            background-attachment: fixed;
+            background-position: center;
+            background-size: cover;
 
             &::after {
                 position: absolute;
@@ -54,15 +58,6 @@
                 z-index: 1;
                 background: @color-background-dark2-70;
                 content: "";
-            }
-
-            .background-image {
-                display: block;
-                width: 100%;
-                height: 100%;
-                object-fit: cover;
-                object-position: top left;
-                opacity: 0.9;
             }
         }
 


### PR DESCRIPTION
Because the backdrop was not set as a `background-image`, a broken image icon could be seen when the backdrop was missing:
<img width="310" alt="Screenshot 2022-01-26 at 19 06 36" src="https://user-images.githubusercontent.com/1777923/152547947-5ffeaf55-5009-4749-8036-2656d94b9e9d.png">

