### PR TITLE
Improvements to MetaDetails Page

### DIFF
--- a/src/common/MetaPreview/MetaPreview.js
+++ b/src/common/MetaPreview/MetaPreview.js
@@ -92,9 +92,16 @@ const MetaPreview = ({ className, compact, name, logo, background, runtime, rele
 
         return trailerStreams[0].deepLinks.player;
     }, [trailerStreams]);
-    const renderLogoFallback = React.useCallback(() => (
-        <Icon className={styles['logo-placeholder-icon']} icon={'ic_broken_link'} />
-    ), []);
+    const logoFallback = ({ currentTarget }) => {
+        currentTarget.onerror = null; // detach handler
+        if (compact) {
+            // replace with blank png
+            currentTarget.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+        } else {
+            // show img.alt without broken image icon
+            currentTarget.className = styles['missing'];
+        }
+    }
     return (
         <div className={classnames(className, styles['meta-preview-container'], { [styles['compact']]: compact })}>
             {
@@ -106,17 +113,14 @@ const MetaPreview = ({ className, compact, name, logo, background, runtime, rele
                     null
             }
             <div className={styles['meta-info-container']}>
-                {
-                    typeof logo === 'string' && logo.length > 0 ?
-                        <Image
-                            className={styles['logo']}
-                            src={logo}
-                            alt={' '}
-                            renderFallback={renderLogoFallback}
-                        />
-                        :
-                        null
-                }
+                <div className={styles['logo-holder']}>
+                    <Image
+                        className={styles['logo']}
+                        src={logo || ''}
+                        alt={name}
+                        onError={logoFallback}
+                    />
+                </div>
                 {
                     (typeof releaseInfo === 'string' && releaseInfo.length > 0) || (released instanceof Date && !isNaN(released.getTime())) || (typeof runtime === 'string' && runtime.length > 0) || linksGroups.has(CONSTANTS.IMDB_LINK_CATEGORY) ?
                         <div className={styles['runtime-release-info-container']}>
@@ -155,7 +159,7 @@ const MetaPreview = ({ className, compact, name, logo, background, runtime, rele
                         null
                 }
                 {
-                    typeof name === 'string' && name.length > 0 ?
+                    compact && typeof name === 'string' && name.length > 0 ?
                         <div className={styles['name-container']}>
                             {name}
                         </div>
@@ -163,7 +167,7 @@ const MetaPreview = ({ className, compact, name, logo, background, runtime, rele
                         null
                 }
                 {
-                    typeof description === 'string' && description.length > 0 ?
+                    compact && typeof description === 'string' && description.length > 0 ?
                         <div className={styles['description-container']}>{description}</div>
                         :
                         null
@@ -172,7 +176,8 @@ const MetaPreview = ({ className, compact, name, logo, background, runtime, rele
                     Array.from(linksGroups.keys())
                         .filter((category) => {
                             return category !== CONSTANTS.IMDB_LINK_CATEGORY &&
-                                category !== CONSTANTS.SHARE_LINK_CATEGORY;
+                                category !== CONSTANTS.SHARE_LINK_CATEGORY &&
+                                category !== 'Writers';
                         })
                         .map((category, index) => (
                             <MetaLinks

--- a/src/common/MetaPreview/MetaPreview.js
+++ b/src/common/MetaPreview/MetaPreview.js
@@ -101,7 +101,7 @@ const MetaPreview = ({ className, compact, name, logo, background, runtime, rele
             // show img.alt without broken image icon
             currentTarget.className = styles['missing'];
         }
-    }
+    };
     return (
         <div className={classnames(className, styles['meta-preview-container'], { [styles['compact']]: compact })}>
             {

--- a/src/common/MetaPreview/styles.less
+++ b/src/common/MetaPreview/styles.less
@@ -89,6 +89,23 @@
             margin: 2rem 0;
         }
 
+        .missing {
+            margin-left: -33px;
+            text-indent: 16px;
+            max-width: 200%;
+            color: white;
+            font-size: 1.5rem;
+            position: absolute;
+            bottom: 1.1rem;
+        }
+
+        .logo-holder {
+            height: 12rem;
+            overflow: hidden;
+            width: 100%;
+            position: relative;
+        }
+
         .logo {
             object-fit: contain;
             object-position: center;
@@ -153,7 +170,7 @@
 
         .name-container {
             margin-top: 1rem;
-            font-size: 1.7rem;
+            font-size: 1.5rem;
             color: @color-surface-light5-90;
         }
 


### PR DESCRIPTION
Changes made:
- removed `meta.name` from MetaDetails Page
- removed `meta.description` from MetaDetails Page
- remove "Writers" from MetaDetails Page
- fallback to blank PNG if logo unavailable (MetaPreview only)
- fallback to `meta.name` (css hack used to hide broken image) if logo unavailable

Before:
<img width="1278" alt="Screenshot 2022-02-04 at 16 44 11" src="https://user-images.githubusercontent.com/1777923/152548421-766a9c96-cce7-4220-b290-8e7e3efc556c.png">

After:
<img width="1278" alt="Screenshot 2022-02-04 at 16 45 01" src="https://user-images.githubusercontent.com/1777923/152548554-0124c86a-eb45-43dd-aa80-75d9355801a6.png">

