### PR TITLE
Fallback to Using Addon Name if Stream Name is Missing

### DIFF
--- a/src/routes/MetaDetails/StreamsList/Stream/Stream.js
+++ b/src/routes/MetaDetails/StreamsList/Stream/Stream.js
@@ -35,7 +35,7 @@ const Stream = ({ className, addonName, name, description, thumbnail, progress, 
                     </div>
                     :
                     <div className={styles['addon-name-container']} title={name}>
-                        <div className={styles['addon-name']}>{name}</div>
+                        <div className={styles['addon-name']}>{name || addonName}</div>
                     </div>
             }
             <div className={styles['info-container']} title={description}>{description}</div>

--- a/src/routes/MetaDetails/StreamsList/Stream/Stream.js
+++ b/src/routes/MetaDetails/StreamsList/Stream/Stream.js
@@ -25,7 +25,7 @@ const Stream = ({ className, addonName, name, description, thumbnail, progress, 
         <Button href={href} {...props} className={classnames(className, styles['stream-container'])} title={addonName}>
             {
                 typeof thumbnail === 'string' && thumbnail.length > 0 ?
-                    <div className={styles['thumbnail-container']} title={name}>
+                    <div className={styles['thumbnail-container']} title={name || addonName}>
                         <Image
                             className={styles['thumbnail']}
                             src={thumbnail}
@@ -34,7 +34,7 @@ const Stream = ({ className, addonName, name, description, thumbnail, progress, 
                         />
                     </div>
                     :
-                    <div className={styles['addon-name-container']} title={name}>
+                    <div className={styles['addon-name-container']} title={name || addonName}>
                         <div className={styles['addon-name']}>{name || addonName}</div>
                     </div>
             }


### PR DESCRIPTION
We use `stream.name` for the left side of the stream element, this is fine in most cases but some don't set `stream.name`, in this case we should fallback to the addon's name.

Before:
<img width="1280" alt="Screenshot 2022-02-04 at 17 01 05" src="https://user-images.githubusercontent.com/1777923/152551888-93856685-4d12-41a6-8dc1-745c12858223.png">

After:
<img width="1281" alt="Screenshot 2022-02-04 at 17 05 33" src="https://user-images.githubusercontent.com/1777923/152552226-9535c2f4-d465-4558-b151-86524e58a98c.png">
