### PR TITLE
Pass `seriesInfo` to Player

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -213,12 +213,12 @@ const Player = ({ urlParams, queryParams }) => {
             let seriesInfo = false;
             if ((player.metaItem?.videos || []).length) {
                 const videoId = player.selected?.streamRequest?.path?.id;
-                const video = player.metaItem.videos.find(vid => vid.id === videoId);
+                const video = player.metaItem.videos.find((vid) => vid.id === videoId);
                 if (video?.season || video?.episode) {
                     seriesInfo = {
                         season: video.season,
                         episode: video.episode,
-                    }
+                    };
                 }
             }
             dispatch({

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -210,6 +210,17 @@ const Player = ({ urlParams, queryParams }) => {
         if (player.selected === null) {
             dispatch({ type: 'command', commandName: 'unload' });
         } else if (streamingServer.baseUrl !== null && streamingServer.baseUrl.type !== 'Loading') {
+            let seriesInfo = false;
+            if ((player.metaItem?.videos || []).length) {
+                const videoId = player.selected?.streamRequest?.path?.id;
+                const video = player.metaItem.videos.find(vid => vid.id === videoId);
+                if (video?.season || video?.episode) {
+                    seriesInfo = {
+                        season: video.season,
+                        episode: video.episode,
+                    }
+                }
+            }
             dispatch({
                 type: 'command',
                 commandName: 'load',
@@ -244,11 +255,12 @@ const Player = ({ urlParams, queryParams }) => {
                             streamingServer.selected.transportUrl
                         :
                         null,
-                    chromecastTransport: chromecast.active ? chromecast.transport : null
+                    chromecastTransport: chromecast.active ? chromecast.transport : null,
+                    seriesInfo,
                 }
             });
         }
-    }, [streamingServer.baseUrl, player.selected, forceTranscoding, audioChannels, casting]);
+    }, [streamingServer.baseUrl, player.metaItem, forceTranscoding, audioChannels, casting]);
     useDeepEqualEffect(() => {
         if (videoState.stream !== null) {
             dispatch({


### PR DESCRIPTION
The video player is relying on `seriesInfo` to be passed too (which includes season and episode, if available), this was never implemented in Stremio Web though.

The problem with this PR is that until now we started the video player instantly as we didn't need any metadata to initiate playback, this PR changes things though as we need to wait for the metadata request to finish in order to have `seriesInfo` available, which is needed to start playback.

This should not be an issue though, as it should not be possible to get to the video player page without going through the meta page, so the meta request should be handled by the local browser cache.

Related PRs:
- https://github.com/Stremio/stremio-video/pull/20
- https://github.com/Stremio/enginefs/pull/19