### PR TITLE
Disable spatial nav on small text links

### DIFF
--- a/src/common/MetaRow/MetaRow.js
+++ b/src/common/MetaRow/MetaRow.js
@@ -24,7 +24,7 @@ const MetaRow = ({ className, title, message, items, itemComponent, deepLinks })
                         }
                         {
                             deepLinks && (typeof deepLinks.discover === 'string' || typeof deepLinks.library === 'string') ?
-                                <Button className={styles['see-all-container']} title={'SEE ALL'} href={deepLinks.discover || deepLinks.library}>
+                                <Button className={styles['see-all-container']} title={'SEE ALL'} href={deepLinks.discover || deepLinks.library} tabIndex={-1}>
                                     <div className={styles['label']}>SEE ALL</div>
                                     <Icon className={styles['icon']} icon={'ic_arrow_thin_right'} />
                                 </Button>

--- a/src/common/MetaRow/MetaRowPlaceholder/MetaRowPlaceholder.js
+++ b/src/common/MetaRow/MetaRowPlaceholder/MetaRowPlaceholder.js
@@ -17,7 +17,7 @@ const MetaRowPlaceholder = ({ className, title, deepLinks }) => {
                 </div>
                 {
                     deepLinks && typeof deepLinks.discover === 'string' ?
-                        <Button className={styles['see-all-container']} title={'SEE ALL'} href={deepLinks.discover}>
+                        <Button className={styles['see-all-container']} title={'SEE ALL'} href={deepLinks.discover} tabIndex={-1}>
                             <div className={styles['label']}>SEE ALL</div>
                             <Icon className={styles['icon']} icon={'ic_arrow_thin_right'} />
                         </Button>

--- a/src/common/StreamingServerWarning/StreamingServerWarning.js
+++ b/src/common/StreamingServerWarning/StreamingServerWarning.js
@@ -42,10 +42,10 @@ const StreamingServerWarning = ({ className }) => {
     return (
         <div className={classnames(className, styles['warning-container'])}>
             <div className={styles['warning-statement']}>Streaming server is not available.</div>
-            <Button className={styles['warning-button']} title={'Later'} onClick={onLaterClick}>
+            <Button className={styles['warning-button']} title={'Later'} onClick={onLaterClick} tabIndex={-1}>
                 <div className={styles['warning-label']}>Later</div>
             </Button>
-            <Button className={styles['warning-button']} title={'Dismiss'} onClick={onDismissClick}>
+            <Button className={styles['warning-button']} title={'Dismiss'} onClick={onDismissClick} tabIndex={-1}>
                 <div className={styles['warning-label']}>Dismiss</div>
             </Button>
         </div>


### PR DESCRIPTION
Disable spatial nav on small text links ("See All" and Streaming Server Notif buttons) as they create the confusion of thinking that the focus is lost.