### PR TITLE
Add meta tags for iOS PWA support

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-title" content="Stremio">
     <link rel="icon" type="image/png" sizes="96x96" href="<%= htmlWebpackPlugin.options.faviconsPath %>/icon-96.png">
+    <link rel="apple-touch-icon" href="<%= htmlWebpackPlugin.options.faviconsPath %>/icon-96.png" />
     <title>Stremio - All you can watch!</title>
     <%= htmlWebpackPlugin.tags.headTags %>
 </head>


### PR DESCRIPTION
Add a couple of meta tags that allow "Add to Homescreen" on iOS to: A) Use the correct icon B) not just open the website in Safari, but open as a fullscreen app
