### PR TITLE
fix: Add autofocus to server url input on settings modal

### DIFF
--- a/src/routes/Settings/Settings.js
+++ b/src/routes/Settings/Settings.js
@@ -594,6 +594,7 @@ const Settings = () => {
                         onCloseRequest={closeConfigureServerUrlModal}>
                         <TextInput
                             ref={configureServerUrlInputRef}
+                            autoFocus={true}
                             className={styles['server-url-input']}
                             type={'text'}
                             defaultValue={streamingServerUrlInput.value}


### PR DESCRIPTION
Related and close: #207

---

I have found all ModalDialog element and looks like this is the only one with TextInput element missing the autoFocus attribute
