### PR TITLE
fix(YoutuberLogo): youtuber logo now shows up

### DIFF
--- a/src/routes/Player/InfoMenu/InfoMenu.js
+++ b/src/routes/Player/InfoMenu/InfoMenu.js
@@ -29,7 +29,7 @@ const InfoMenu = ({ className, ...props }) => {
                         className={styles['meta-preview']}
                         compact={true}
                         name={metaItem.name}
-                        logo={metaItem.logo}
+                        logo={metaItem.poster}
                         runtime={metaItem.runtime}
                         releaseInfo={metaItem.releaseInfo}
                         released={metaItem.released}


### PR DESCRIPTION
closes #362 

Youtuber logos will now show up in the info menu. Tried implementing banners but requires no-cores policy, so gave up on that.

![image](https://github.com/Stremio/stremio-web/assets/97270760/e1255d29-0b6e-4648-a6ea-6f9db305d6e7)
