### PR TITLE
Remove Infuse From iOS Ext Players

### DIFF
--- a/src/common/externalPlayerOptions.js
+++ b/src/common/externalPlayerOptions.js
@@ -7,8 +7,7 @@ let options = [{ label: 'EXTERNAL_PLAYER_DISABLED', value: 'internal' }];
 if (platform.name === 'ios') {
     options = options.concat([
         { label: 'VLC', value: 'vlc' },
-        { label: 'Outplayer', value: 'outplayer' },
-        { label: 'Infuse', value: 'infuse' }
+        { label: 'Outplayer', value: 'outplayer' }
     ]);
 } else if (platform.name === 'android') {
     options = options.concat([


### PR DESCRIPTION
There are still some bugs with Infuse, it doesn't always start playback.

Should not be available until fixed. (most probably on the Infuse side)