### PR TITLE
add a long press option to the button module based on timeout. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
                 "react-is": "18.2.0",
                 "spatial-navigation-polyfill": "https://github.com/Stremio/spatial-navigation.git#64871b1422466f5f45d24ebc8bbd315b2ebab6a6",
                 "stremio-translations": "https://github.com/Stremio/stremio-translations.git#92675658de92113c5888cf5e57003e468e8b8c9c",
-                "url": "0.11.0"
+                "url": "0.11.0",
+                "use-long-press": "^3.1.5"
             },
             "devDependencies": {
                 "@babel/core": "7.16.0",
@@ -13664,6 +13665,14 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
+        "node_modules/use-long-press": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/use-long-press/-/use-long-press-3.1.5.tgz",
+            "integrity": "sha512-bnwk2SlvLLpeJPkNYSGkc59q5YNV9V/fLDkSOAF2p7Xt0zw3iYHEmgEGkNYkK7zEIEyRFi5CczKsT7MN99UzVQ==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/use-sidecar": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
@@ -25103,6 +25112,12 @@
                     "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
                 }
             }
+        },
+        "use-long-press": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/use-long-press/-/use-long-press-3.1.5.tgz",
+            "integrity": "sha512-bnwk2SlvLLpeJPkNYSGkc59q5YNV9V/fLDkSOAF2p7Xt0zw3iYHEmgEGkNYkK7zEIEyRFi5CczKsT7MN99UzVQ==",
+            "requires": {}
         },
         "use-sidecar": {
             "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
         "react-is": "18.2.0",
         "spatial-navigation-polyfill": "https://github.com/Stremio/spatial-navigation.git#64871b1422466f5f45d24ebc8bbd315b2ebab6a6",
         "stremio-translations": "https://github.com/Stremio/stremio-translations.git#92675658de92113c5888cf5e57003e468e8b8c9c",
-        "url": "0.11.0"
+        "url": "0.11.0",
+        "use-long-press": "^3.1.5"
     },
     "devDependencies": {
         "@babel/core": "7.16.0",

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -5,7 +5,19 @@ const PropTypes = require('prop-types');
 const classnames = require('classnames');
 const styles = require('./styles');
 
-const Button = React.forwardRef(({ className, href, disabled, children, ...props }, ref) => {
+const Button = React.forwardRef(({ className, href, disabled, children, onLongPress, ...props }, ref) => {
+    let pressTimer = null;
+    const onTouchStart = function () {
+        pressTimer = setTimeout(function () {
+            if (typeof onLongPress === 'function') {
+                //alert('longpress detected');
+                onLongPress();
+            }
+        }, 600); // values less than 600 will cause an artifact of previous menus staying on screen.
+    };
+    const onTouchEnd = function () {
+        clearTimeout(pressTimer);
+    };
     const onKeyDown = React.useCallback((event) => {
         if (typeof props.onKeyDown === 'function') {
             props.onKeyDown(event);
@@ -36,7 +48,9 @@ const Button = React.forwardRef(({ className, href, disabled, children, ...props
             className: classnames(className, styles['button-container'], { 'disabled': disabled }),
             href,
             onKeyDown,
-            onMouseDown
+            onMouseDown,
+            onTouchStart,
+            onTouchEnd,
         },
         children
     );
@@ -50,7 +64,8 @@ Button.propTypes = {
     disabled: PropTypes.bool,
     children: PropTypes.node,
     onKeyDown: PropTypes.func,
-    onMouseDown: PropTypes.func
+    onMouseDown: PropTypes.func,
+    onLongPress: PropTypes.func,
 };
 
 module.exports = Button;

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -8,6 +8,9 @@ const { useLongPress } = require('use-long-press');
 
 const Button = React.forwardRef(({ className, href, disabled, children, onLongPress, ...props }, ref) => {
     const longPress = useLongPress(onLongPress);
+    // exoposing them to make it easier to know which handlers are exported,
+    // in case a change to one of them is needed in the future.
+    const {onPointerDown, onPointerMove, onPointerUp, onPointerLeave} = longPress();
     const onKeyDown = React.useCallback((event) => {
         if (typeof props.onKeyDown === 'function') {
             props.onKeyDown(event);
@@ -39,7 +42,7 @@ const Button = React.forwardRef(({ className, href, disabled, children, onLongPr
             href,
             onKeyDown,
             onMouseDown,
-            ...longPress()
+            onPointerDown, onPointerMove, onPointerUp, onPointerLeave
         },
         children
     );

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -13,7 +13,7 @@ const Button = React.forwardRef(({ className, href, disabled, children, onLongPr
                 //alert('longpress detected');
                 onLongPress();
             }
-        }, 600); // values less than 600 will cause an artifact of previous menus staying on screen.
+        }, 650); // an artifact of previous menus staying on the screen will happen on Safari if the timeout was set to 600 and less, and 650 for PWA.
     };
     const onTouchEnd = function () {
         clearTimeout(pressTimer);

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -4,20 +4,10 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const classnames = require('classnames');
 const styles = require('./styles');
+const { useLongPress } = require('use-long-press');
 
 const Button = React.forwardRef(({ className, href, disabled, children, onLongPress, ...props }, ref) => {
-    const longPressTimeout = React.useRef(null);
-    const onTouchStart = React.useCallback((event) => {
-        longPressTimeout.current = setTimeout(function () {
-            clearTimeout(longPressTimeout.current);
-            if (typeof onLongPress === 'function') {
-                onLongPress(event);
-            }
-        }, 500);
-    }, [onLongPress]);
-    const onTouchEnd = React.useCallback(() => {
-        clearTimeout(longPressTimeout.current);
-    }, []);
+    const longPress = useLongPress(onLongPress);
     const onKeyDown = React.useCallback((event) => {
         if (typeof props.onKeyDown === 'function') {
             props.onKeyDown(event);
@@ -49,8 +39,7 @@ const Button = React.forwardRef(({ className, href, disabled, children, onLongPr
             href,
             onKeyDown,
             onMouseDown,
-            onTouchStart,
-            onTouchEnd,
+            ...longPress()
         },
         children
     );

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -14,8 +14,7 @@ const Button = React.forwardRef(({ className, href, disabled, children, onLongPr
             }
         }, 650); // an artifact of previous menus staying on the screen will happen on Safari if the timeout was set to 600 and less, and 650 for PWA.
     };
-    const onTouchEnd = function (event) {
-        //event.preventDefault();
+    const onTouchEnd = function () {
         clearTimeout(pressTimer);
     };
     const onKeyDown = React.useCallback((event) => {

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -7,10 +7,7 @@ const styles = require('./styles');
 const { useLongPress } = require('use-long-press');
 
 const Button = React.forwardRef(({ className, href, disabled, children, onLongPress, ...props }, ref) => {
-    const longPress = useLongPress(onLongPress);
-    // exoposing them to make it easier to know which handlers are exported,
-    // in case a change to one of them is needed in the future.
-    const {onPointerDown, onPointerMove, onPointerUp, onPointerLeave} = longPress();
+    const longPress = useLongPress(onLongPress, { detect: 'pointer' });
     const onKeyDown = React.useCallback((event) => {
         if (typeof props.onKeyDown === 'function') {
             props.onKeyDown(event);
@@ -42,7 +39,7 @@ const Button = React.forwardRef(({ className, href, disabled, children, onLongPr
             href,
             onKeyDown,
             onMouseDown,
-            onPointerDown, onPointerMove, onPointerUp, onPointerLeave
+            ...longPress()
         },
         children
     );

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -6,17 +6,17 @@ const classnames = require('classnames');
 const styles = require('./styles');
 
 const Button = React.forwardRef(({ className, href, disabled, children, onLongPress, ...props }, ref) => {
-    let pressTimer = null;
-    const onTouchStart = function (event) {
-        pressTimer = setTimeout(function () {
+    const longPressTimeout = React.useRef(null);
+    const onTouchStart = React.useCallback((event) => {
+        longPressTimeout.current = setTimeout(function () {
             if (typeof onLongPress === 'function') {
                 onLongPress(event);
             }
         }, 650); // an artifact of previous menus staying on the screen will happen on Safari if the timeout was set to 600 and less, and 650 for PWA.
-    };
-    const onTouchEnd = function () {
-        clearTimeout(pressTimer);
-    };
+    }, [onLongPress]);
+    const onTouchEnd = React.useCallback(() => {
+        clearTimeout(longPressTimeout.current);
+    }, []);
     const onKeyDown = React.useCallback((event) => {
         if (typeof props.onKeyDown === 'function') {
             props.onKeyDown(event);

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -7,15 +7,15 @@ const styles = require('./styles');
 
 const Button = React.forwardRef(({ className, href, disabled, children, onLongPress, ...props }, ref) => {
     let pressTimer = null;
-    const onTouchStart = function () {
+    const onTouchStart = function (event) {
         pressTimer = setTimeout(function () {
             if (typeof onLongPress === 'function') {
-                //alert('longpress detected');
-                onLongPress();
+                onLongPress(event);
             }
         }, 650); // an artifact of previous menus staying on the screen will happen on Safari if the timeout was set to 600 and less, and 650 for PWA.
     };
-    const onTouchEnd = function () {
+    const onTouchEnd = function (event) {
+        //event.preventDefault();
         clearTimeout(pressTimer);
     };
     const onKeyDown = React.useCallback((event) => {

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -9,6 +9,7 @@ const Button = React.forwardRef(({ className, href, disabled, children, onLongPr
     const longPressTimeout = React.useRef(null);
     const onTouchStart = React.useCallback((event) => {
         longPressTimeout.current = setTimeout(function () {
+            clearTimeout(longPressTimeout.current);
             if (typeof onLongPress === 'function') {
                 onLongPress(event);
             }

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -13,8 +13,11 @@ const Button = React.forwardRef(({ className, href, disabled, children, onLongPr
             props.onKeyDown(event);
         }
 
-        if (event.key === 'Enter' && !event.nativeEvent.buttonClickPrevented) {
-            event.currentTarget.click();
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            if (!event.nativeEvent.buttonClickPrevented) {
+                event.currentTarget.click();
+            }
         }
     }, [props.onKeyDown]);
     const onMouseDown = React.useCallback((event) => {

--- a/src/common/Button/Button.js
+++ b/src/common/Button/Button.js
@@ -12,7 +12,7 @@ const Button = React.forwardRef(({ className, href, disabled, children, onLongPr
             if (typeof onLongPress === 'function') {
                 onLongPress(event);
             }
-        }, 650); // an artifact of previous menus staying on the screen will happen on Safari if the timeout was set to 600 and less, and 650 for PWA.
+        }, 500);
     }, [onLongPress]);
     const onTouchEnd = React.useCallback(() => {
         clearTimeout(longPressTimeout.current);

--- a/src/common/Button/styles.less
+++ b/src/common/Button/styles.less
@@ -3,11 +3,19 @@
 @import (reference) '~@stremio/stremio-colors/less/stremio-colors.less';
 
 .button-container {
+    // IOS specific 
+    // prevents showing the default context-menu when long pressing an anchor in safari.
+    -webkit-touch-callout: none !important;
+    // prevents user from selecting text from a div on long pressing in safari.
+    -webkit-user-select: none !important;
+
+    user-select: none !important;
+
     outline-width: var(--focus-outline-size);
     outline-color: @color-surface-light5;
     outline-offset: calc(-1 * var(--focus-outline-size));
     cursor: pointer;
-
+    
     &:focus {
         outline-style: solid;
     }

--- a/src/common/Button/styles.less
+++ b/src/common/Button/styles.less
@@ -7,6 +7,7 @@
     outline-color: @color-surface-light5;
     outline-offset: calc(-1 * var(--focus-outline-size));
     cursor: pointer;
+
     &:focus {
         outline-style: solid;
     }

--- a/src/common/Button/styles.less
+++ b/src/common/Button/styles.less
@@ -7,7 +7,6 @@
     outline-color: @color-surface-light5;
     outline-offset: calc(-1 * var(--focus-outline-size));
     cursor: pointer;
-    
     &:focus {
         outline-style: solid;
     }

--- a/src/common/Button/styles.less
+++ b/src/common/Button/styles.less
@@ -3,10 +3,6 @@
 @import (reference) '~@stremio/stremio-colors/less/stremio-colors.less';
 
 .button-container {
-    // IOS specific 
-    // prevents showing the default context-menu when long pressing an anchor in safari.
-    -webkit-touch-callout: none !important;
-
     outline-width: var(--focus-outline-size);
     outline-color: @color-surface-light5;
     outline-offset: calc(-1 * var(--focus-outline-size));

--- a/src/common/Button/styles.less
+++ b/src/common/Button/styles.less
@@ -6,10 +6,6 @@
     // IOS specific 
     // prevents showing the default context-menu when long pressing an anchor in safari.
     -webkit-touch-callout: none !important;
-    // prevents user from selecting text from a div on long pressing in safari.
-    -webkit-user-select: none !important;
-
-    user-select: none !important;
 
     outline-width: var(--focus-outline-size);
     outline-color: @color-surface-light5;

--- a/src/common/Popup/Popup.js
+++ b/src/common/Popup/Popup.js
@@ -28,9 +28,6 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
     const menuOnMouseDown = React.useCallback((event) => {
         event.nativeEvent.closePopupPrevented = true;
     }, []);
-    const menuOnTouchStart = React.useCallback((event) => {
-        event.nativeEvent.closePopupPrevented = true;
-    }, []);
     React.useEffect(() => {
         const onCloseEvent = (event) => {
             if (!event.closePopupPrevented && typeof onCloseRequest === 'function') {
@@ -109,7 +106,7 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
         ref: labelRef,
         className: classnames(styles['label-container'], props.className, { 'active': open }),
         children: open ?
-            <FocusLock ref={menuRef} className={classnames(styles['menu-container'], { [styles[`menu-direction-${autoDirection}`]]: !direction }, { [styles[`menu-direction-${direction}`]]: direction })} autoFocus={false} lockProps={{ onMouseDown: menuOnMouseDown, ontouchstart: menuOnTouchStart }}>
+            <FocusLock ref={menuRef} className={classnames(styles['menu-container'], { [styles[`menu-direction-${autoDirection}`]]: !direction }, { [styles[`menu-direction-${direction}`]]: direction })} autoFocus={false} lockProps={{ onMouseDown: menuOnMouseDown}}>
                 {renderMenu()}
             </FocusLock>
             :

--- a/src/common/Popup/Popup.js
+++ b/src/common/Popup/Popup.js
@@ -47,7 +47,7 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
                             onCloseRequest(closeEvent);
                         }
                         break;
-                    case 'touchstart':
+                    case 'pointerdown':
                         if (event.target !== document.documentElement && !labelRef.current.contains(event.target)) {
                             onCloseRequest(closeEvent);
                         }
@@ -58,12 +58,12 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
         if (routeFocused && open) {
             window.addEventListener('keydown', onCloseEvent);
             window.addEventListener('mousedown', onCloseEvent);
-            window.addEventListener('touchstart', onCloseEvent);
+            window.addEventListener('pointerdown', onCloseEvent);
         }
         return () => {
             window.removeEventListener('keydown', onCloseEvent);
             window.removeEventListener('mousedown', onCloseEvent);
-            window.removeEventListener('touchstart', onCloseEvent);
+            window.removeEventListener('pointerdown', onCloseEvent);
         };
     }, [routeFocused, open, onCloseRequest, dataset]);
     React.useLayoutEffect(() => {

--- a/src/common/Popup/Popup.js
+++ b/src/common/Popup/Popup.js
@@ -42,7 +42,12 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
                             onCloseRequest(closeEvent);
                         }
                         break;
-                    case 'mousedown' || 'touchstart':
+                    case 'mousedown':
+                        if (event.target !== document.documentElement && !labelRef.current.contains(event.target)) {
+                            onCloseRequest(closeEvent);
+                        }
+                        break;
+                    case 'touchstart':
                         if (event.target !== document.documentElement && !labelRef.current.contains(event.target)) {
                             onCloseRequest(closeEvent);
                         }
@@ -106,7 +111,7 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
         ref: labelRef,
         className: classnames(styles['label-container'], props.className, { 'active': open }),
         children: open ?
-            <FocusLock ref={menuRef} className={classnames(styles['menu-container'], { [styles[`menu-direction-${autoDirection}`]]: !direction }, { [styles[`menu-direction-${direction}`]]: direction })} autoFocus={false} lockProps={{ onMouseDown: menuOnMouseDown}}>
+            <FocusLock ref={menuRef} className={classnames(styles['menu-container'], { [styles[`menu-direction-${autoDirection}`]]: !direction }, { [styles[`menu-direction-${direction}`]]: direction })} autoFocus={false} lockProps={{ onMouseDown: menuOnMouseDown }}>
                 {renderMenu()}
             </FocusLock>
             :

--- a/src/common/Popup/Popup.js
+++ b/src/common/Popup/Popup.js
@@ -28,6 +28,9 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
     const menuOnMouseDown = React.useCallback((event) => {
         event.nativeEvent.closePopupPrevented = true;
     }, []);
+    const menuOnTouchStart = React.useCallback((event) => {
+        event.nativeEvent.closePopupPrevented = true;
+    }, []);
     React.useEffect(() => {
         const onCloseEvent = (event) => {
             if (!event.closePopupPrevented && typeof onCloseRequest === 'function') {
@@ -42,7 +45,7 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
                             onCloseRequest(closeEvent);
                         }
                         break;
-                    case 'mousedown':
+                    case 'mousedown' || 'touchstart':
                         if (event.target !== document.documentElement && !labelRef.current.contains(event.target)) {
                             onCloseRequest(closeEvent);
                         }
@@ -53,10 +56,12 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
         if (routeFocused && open) {
             window.addEventListener('keydown', onCloseEvent);
             window.addEventListener('mousedown', onCloseEvent);
+            window.addEventListener('touchstart', onCloseEvent);
         }
         return () => {
             window.removeEventListener('keydown', onCloseEvent);
             window.removeEventListener('mousedown', onCloseEvent);
+            window.removeEventListener('touchstart', onCloseEvent);
         };
     }, [routeFocused, open, onCloseRequest, dataset]);
     React.useLayoutEffect(() => {
@@ -104,7 +109,7 @@ const Popup = ({ open, direction, renderLabel, renderMenu, dataset, onCloseReque
         ref: labelRef,
         className: classnames(styles['label-container'], props.className, { 'active': open }),
         children: open ?
-            <FocusLock ref={menuRef} className={classnames(styles['menu-container'], { [styles[`menu-direction-${autoDirection}`]]: !direction }, { [styles[`menu-direction-${direction}`]]: direction })} autoFocus={false} lockProps={{ onMouseDown: menuOnMouseDown }}>
+            <FocusLock ref={menuRef} className={classnames(styles['menu-container'], { [styles[`menu-direction-${autoDirection}`]]: !direction }, { [styles[`menu-direction-${direction}`]]: direction })} autoFocus={false} lockProps={{ onMouseDown: menuOnMouseDown, ontouchstart: menuOnTouchStart }}>
                 {renderMenu()}
             </FocusLock>
             :

--- a/src/common/Popup/styles.less
+++ b/src/common/Popup/styles.less
@@ -3,6 +3,10 @@
 @import (reference) '~@stremio/stremio-colors/less/stremio-colors.less';
 
 .label-container {
+    // IOS specific 
+    // prevents showing the default context-menu when long pressing an anchor in safari.
+    -webkit-touch-callout: none !important;
+
     position: relative;
     overflow: visible;
 

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -31,7 +31,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
         }
     }, [toggleMenu]);
     const popupLabelOnLongPress = React.useCallback((event) => {
-        if (!event.pointerType === 'mouse' && !event.nativeEvent.togglePopupPrevented) {
+        if (event.pointerType !== 'mouse' && !event.nativeEvent.togglePopupPrevented) {
             toggleMenu();
         }
     }, [toggleMenu]);

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -31,8 +31,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
         }
     }, [toggleMenu]);
     const popupLabelOnLongPress = React.useCallback((event) => {
-        if (!event.nativeEvent.togglePopupPrevented && !event.nativeEvent.ctrlKey) {
-            if (event.cancelable) event.preventDefault();
+        if (!event.nativeEvent.togglePopupPrevented) {
             toggleMenu();
         }
     }, [toggleMenu]);

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -21,21 +21,20 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             toggleMenu();
         }
     }, []);
-    const popupLabelOnKeyDown = React.useCallback((event) => {
-        event.nativeEvent.buttonClickPrevented = true;
-    }, []);
     const popupLabelOnContextMenu = React.useCallback((event) => {
         if (!event.nativeEvent.togglePopupPrevented && !event.nativeEvent.ctrlKey) {
             event.preventDefault();
-            toggleMenu();
+            if (event.nativeEvent.pointerType === 'mouse') {
+                toggleMenu();
+            }
         }
     }, [toggleMenu]);
     const popupLabelOnLongPress = React.useCallback((event) => {
-        if (event.pointerType !== 'mouse' && !event.nativeEvent.togglePopupPrevented) {
+        if (event.nativeEvent.pointerType !== 'mouse' && !event.nativeEvent.togglePopupPrevented) {
             toggleMenu();
         }
     }, [toggleMenu]);
-    const popupMenuOTouchStart = React.useCallback((event) => {
+    const popupMenuOnPointerDown = React.useCallback((event) => {
         event.nativeEvent.togglePopupPrevented = true;
     }, []);
     const popupMenuOnContextMenu = React.useCallback((event) => {
@@ -43,6 +42,9 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     }, []);
     const popupMenuOnClick = React.useCallback((event) => {
         event.nativeEvent.togglePopupPrevented = true;
+    }, []);
+    const popupMenuOnKeyDown = React.useCallback((event) => {
+        event.nativeEvent.buttonClickPrevented = true;
     }, []);
     const toggleWatchedOnClick = React.useCallback((event) => {
         event.preventDefault();
@@ -141,7 +143,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     }, []);
     const renderMenu = React.useMemo(() => function renderMenu() {
         return (
-            <div className={styles['context-menu-content']} onTouchStart={popupMenuOTouchStart} onContextMenu={popupMenuOnContextMenu} onClick={popupMenuOnClick}>
+            <div className={styles['context-menu-content']} onPointerDown={popupMenuOnPointerDown} onContextMenu={popupMenuOnContextMenu} onClick={popupMenuOnClick} onKeyDown={popupMenuOnKeyDown}>
                 <Button className={styles['context-menu-option-container']} title={'Watch'}>
                     <div className={styles['context-menu-option-label']}>{t('CTX_WATCH')}</div>
                 </Button>
@@ -171,13 +173,12 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             href={href}
             {...props}
             onClick={popupLabelOnClick}
-            onKeyDown={popupLabelOnKeyDown}
+            onLongPress={popupLabelOnLongPress}
             onContextMenu={popupLabelOnContextMenu}
             open={menuOpen}
             onCloseRequest={closeMenu}
             renderLabel={renderLabel}
             renderMenu={renderMenu}
-            onLongPress={popupLabelOnLongPress}
         />
     );
 };

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -36,7 +36,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             toggleMenu();
         }
     }, [toggleMenu]);
-    const popupMenuOnLongPress = React.useCallback((event) => {
+    const popupMenuOTouchStart = React.useCallback((event) => {
         event.nativeEvent.togglePopupPrevented = true;
     }, []);
     const popupMenuOnContextMenu = React.useCallback((event) => {
@@ -142,7 +142,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     }, []);
     const renderMenu = React.useMemo(() => function renderMenu() {
         return (
-            <div className={styles['context-menu-content']} onTouchStart={popupMenuOnLongPress} onContextMenu={popupMenuOnContextMenu} onClick={popupMenuOnClick}>
+            <div className={styles['context-menu-content']} onTouchStart={popupMenuOTouchStart} onContextMenu={popupMenuOnContextMenu} onClick={popupMenuOnClick}>
                 <Button className={styles['context-menu-option-container']} title={'Watch'}>
                     <div className={styles['context-menu-option-label']}>{t('CTX_WATCH')}</div>
                 </Button>

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -31,9 +31,14 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
         }
     }, [toggleMenu]);
     const popupLabelOnLongPress = React.useCallback((event) => {
-        event.preventDefault();
-        toggleMenu();
+        if (!event.nativeEvent.togglePopupPrevented && !event.nativeEvent.ctrlKey) {
+            event.preventDefault();
+            toggleMenu();
+        }
     }, [toggleMenu]);
+    const popupMenuOnLongPress = React.useCallback((event) => {
+        event.nativeEvent.togglePopupPrevented = true;
+    }, []);
     const popupMenuOnContextMenu = React.useCallback((event) => {
         event.nativeEvent.togglePopupPrevented = true;
     }, []);
@@ -137,7 +142,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     }, []);
     const renderMenu = React.useMemo(() => function renderMenu() {
         return (
-            <div className={styles['context-menu-content']} onContextMenu={popupMenuOnContextMenu} onClick={popupMenuOnClick}>
+            <div className={styles['context-menu-content']} onTouchStart={popupMenuOnLongPress} onContextMenu={popupMenuOnContextMenu} onClick={popupMenuOnClick}>
                 <Button className={styles['context-menu-option-container']} title={'Watch'}>
                     <div className={styles['context-menu-option-label']}>{t('CTX_WATCH')}</div>
                 </Button>

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -29,6 +29,9 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             toggleMenu();
         }
     }, [toggleMenu]);
+    const popupLabelOnLongPress = React.useCallback(() => {
+        toggleMenu();
+    }, [toggleMenu]);
     const popupMenuOnContextMenu = React.useCallback((event) => {
         event.nativeEvent.togglePopupPrevented = true;
     }, []);
@@ -168,6 +171,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             onCloseRequest={closeMenu}
             renderLabel={renderLabel}
             renderMenu={renderMenu}
+            onLongPress={popupLabelOnLongPress}
         />
     );
 };

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -30,7 +30,8 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             toggleMenu();
         }
     }, [toggleMenu]);
-    const popupLabelOnLongPress = React.useCallback(() => {
+    const popupLabelOnLongPress = React.useCallback((event) => {
+        event.preventDefault();
         toggleMenu();
     }, [toggleMenu]);
     const popupMenuOnContextMenu = React.useCallback((event) => {

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -3,6 +3,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const classnames = require('classnames');
+const { t } = require('i18next');
 const { useServices } = require('stremio/services');
 const { useRouteFocused } = require('stremio-router');
 const Icon = require('@stremio/stremio-icons/dom');
@@ -137,10 +138,10 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
         return (
             <div className={styles['context-menu-content']} onContextMenu={popupMenuOnContextMenu} onClick={popupMenuOnClick}>
                 <Button className={styles['context-menu-option-container']} title={'Watch'}>
-                    <div className={styles['context-menu-option-label']}>Watch</div>
+                    <div className={styles['context-menu-option-label']}>{t('CTX_WATCH')}</div>
                 </Button>
                 <Button className={styles['context-menu-option-container']} title={watched ? 'Mark as non-watched' : 'Mark as watched'} onClick={toggleWatchedOnClick}>
-                    <div className={styles['context-menu-option-label']}>{watched ? 'Mark as non-watched' : 'Mark as watched'}</div>
+                    <div className={styles['context-menu-option-label']}>{watched ? t('CTX_MARK_NON_WATCHED') : t('CTX_MARK_WATCHED')}</div>
                 </Button>
             </div>
         );

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -32,7 +32,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     }, [toggleMenu]);
     const popupLabelOnLongPress = React.useCallback((event) => {
         if (!event.nativeEvent.togglePopupPrevented && !event.nativeEvent.ctrlKey) {
-            event.preventDefault();
+            if (event.cancelable) event.preventDefault();
             toggleMenu();
         }
     }, [toggleMenu]);

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -31,7 +31,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
         }
     }, [toggleMenu]);
     const popupLabelOnLongPress = React.useCallback((event) => {
-        if (!event.nativeEvent.togglePopupPrevented) {
+        if (!event.pointerType === 'mouse' && !event.nativeEvent.togglePopupPrevented) {
             toggleMenu();
         }
     }, [toggleMenu]);

--- a/src/routes/MetaDetails/VideosList/Video/styles.less
+++ b/src/routes/MetaDetails/VideosList/Video/styles.less
@@ -12,11 +12,6 @@
 }
 
 .video-container {
-    // IOS specific 
-    // prevents showing the default context-menu when long pressing an anchor in safari.
-    -webkit-touch-callout: none !important; 
-    // prevents user from selecting text from a div on long pressing in safari.
-    -webkit-user-select: none!important; 
 
     display: flex;
     flex-direction: row;
@@ -33,6 +28,7 @@
         flex: none;
 
         .thumbnail {
+            pointer-events: none;
             display: block;
             width: 7.5rem;
             height: 5rem;

--- a/src/routes/MetaDetails/VideosList/Video/styles.less
+++ b/src/routes/MetaDetails/VideosList/Video/styles.less
@@ -12,6 +12,12 @@
 }
 
 .video-container {
+    // IOS specific 
+    // prevents showing the default context-menu when long pressing an anchor in safari.
+    -webkit-touch-callout: none !important; 
+    // prevents user from selecting text from a div on long pressing in safari.
+    -webkit-user-select: none!important; 
+
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;

--- a/src/routes/MetaDetails/VideosList/Video/styles.less
+++ b/src/routes/MetaDetails/VideosList/Video/styles.less
@@ -12,7 +12,6 @@
 }
 
 .video-container {
-
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;


### PR DESCRIPTION
this makes a long press on mobile browser execute a function instead of the default popup menu when long-pressing an anchor. (fully working on ios safari and the PWA)

it's currently only used in video objects (series episodes) for watching or marking as watched. 

documentation regarding the added CSS: [Safari CSS Properties](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html).


it was only tested on:
- ios safari : working as expected.
- ios PWA: working as expected.
- ios firefox: working as expected.
- ios chrome: working as expected, but the context menu of the thumbnail image appears (bad UX).
- windows chrome: working as expected.
- windows chrome with device mode: the "mark as watched" appears, but will disappear if stopped pressing directly without moving the mouse slightly first. 