### PR TITLE
fix: add missing prop to the discover preview

### DIFF
--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -164,6 +164,7 @@ const Discover = ({ urlParams, queryParams }) => {
                             released={selectedMetaItem.released}
                             description={selectedMetaItem.description}
                             deepLinks={selectedMetaItem.deepLinks}
+                            links={selectedMetaItem.links}
                             trailerStreams={selectedMetaItem.trailerStreams}
                             inLibrary={selectedMetaItem.inLibrary}
                             toggleInLibrary={selectedMetaItem.inLibrary ? removeFromLibrary : addToLibrary}


### PR DESCRIPTION
There was a missing prop needed to display imdb rating, genres, cast and directors on the discover preview.

![image](https://github.com/Stremio/stremio-web/assets/16787161/17d3a40c-8e44-4647-a718-737357850aaf)
