### PR TITLE
use github ref_name for all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
-          destination_dir: ${{ github.ref_name != 'development' && github.ref_name || '' }}
+          destination_dir: ${{ github.ref_name }}
           allow_empty_commit: true


### PR DESCRIPTION
With the current implementation all of the branches that are deployed to gh pages are gone, once a PR is merged into development