### PR TITLE
fix(Video): context menu was not working on Firefox

### DIFF
--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -24,13 +24,6 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     const popupLabelOnContextMenu = React.useCallback((event) => {
         if (!event.nativeEvent.togglePopupPrevented && !event.nativeEvent.ctrlKey) {
             event.preventDefault();
-            if (event.nativeEvent.pointerType === 'mouse') {
-                toggleMenu();
-            }
-        }
-    }, [toggleMenu]);
-    const popupLabelOnLongPress = React.useCallback((event) => {
-        if (event.nativeEvent.pointerType !== 'mouse' && !event.nativeEvent.togglePopupPrevented) {
             toggleMenu();
         }
     }, [toggleMenu]);
@@ -173,7 +166,6 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             href={href}
             {...props}
             onClick={popupLabelOnClick}
-            onLongPress={popupLabelOnLongPress}
             onContextMenu={popupLabelOnContextMenu}
             open={menuOpen}
             onCloseRequest={closeMenu}

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -24,7 +24,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     const popupLabelOnContextMenu = React.useCallback((event) => {
         if (!event.nativeEvent.togglePopupPrevented && !event.nativeEvent.ctrlKey) {
             event.preventDefault();
-            if (event.nativeEvent.pointerType === 'mouse' || event.nativeEvent.button === 2) {
+            if (event.nativeEvent.pointerType === 'mouse' || (event.nativeEvent.button === 2 && event.nativeEvent.button === 0)) {
                 toggleMenu();
             }
         }
@@ -173,6 +173,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             href={href}
             {...props}
             onClick={popupLabelOnClick}
+            onLongPress={popupLabelOnLongPress}
             onContextMenu={popupLabelOnContextMenu}
             onLongPress={popupLabelOnLongPress}
             open={menuOpen}

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -24,6 +24,13 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     const popupLabelOnContextMenu = React.useCallback((event) => {
         if (!event.nativeEvent.togglePopupPrevented && !event.nativeEvent.ctrlKey) {
             event.preventDefault();
+            if (event.nativeEvent.pointerType === 'mouse' || event.nativeEvent.button === 2) {
+                toggleMenu();
+            }
+        }
+    }, [toggleMenu]);
+    const popupLabelOnLongPress = React.useCallback((event) => {
+        if (event.nativeEvent.pointerType !== 'mouse' && !event.nativeEvent.togglePopupPrevented) {
             toggleMenu();
         }
     }, [toggleMenu]);
@@ -167,6 +174,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             {...props}
             onClick={popupLabelOnClick}
             onContextMenu={popupLabelOnContextMenu}
+            onLongPress={popupLabelOnLongPress}
             open={menuOpen}
             onCloseRequest={closeMenu}
             renderLabel={renderLabel}

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -24,7 +24,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     const popupLabelOnContextMenu = React.useCallback((event) => {
         if (!event.nativeEvent.togglePopupPrevented && !event.nativeEvent.ctrlKey) {
             event.preventDefault();
-            if (event.nativeEvent.pointerType === 'mouse' || (event.nativeEvent.button === 2 && event.nativeEvent.button === 0)) {
+            if (event.nativeEvent.pointerType === 'mouse' || (event.nativeEvent.button === 2 && event.nativeEvent.buttons === 0)) {
                 toggleMenu();
             }
         }

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -15,18 +15,17 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     const { core } = useServices();
     const routeFocused = useRouteFocused();
     const [menuOpen, , closeMenu, toggleMenu] = useBinaryState(false);
-    const popupLabelOnClick = React.useCallback((event) => {
-        if (!event.nativeEvent.togglePopupPrevented && event.nativeEvent.ctrlKey) {
-            event.preventDefault();
-            toggleMenu();
+    const popupLabelOnMouseUp = React.useCallback((event) => {
+        if (!event.nativeEvent.togglePopupPrevented) {
+            if (event.nativeEvent.ctrlKey || event.nativeEvent.button === 2) {
+                event.preventDefault();
+                toggleMenu();
+            }
         }
     }, []);
     const popupLabelOnContextMenu = React.useCallback((event) => {
         if (!event.nativeEvent.togglePopupPrevented && !event.nativeEvent.ctrlKey) {
             event.preventDefault();
-            if (event.nativeEvent.pointerType === 'mouse' || (event.nativeEvent.button === 2 && event.nativeEvent.buttons === 0)) {
-                toggleMenu();
-            }
         }
     }, [toggleMenu]);
     const popupLabelOnLongPress = React.useCallback((event) => {
@@ -172,7 +171,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             scheduled={scheduled}
             href={href}
             {...props}
-            onClick={popupLabelOnClick}
+            onMouseUp={popupLabelOnMouseUp}
             onLongPress={popupLabelOnLongPress}
             onContextMenu={popupLabelOnContextMenu}
             open={menuOpen}

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -175,7 +175,6 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             onClick={popupLabelOnClick}
             onLongPress={popupLabelOnLongPress}
             onContextMenu={popupLabelOnContextMenu}
-            onLongPress={popupLabelOnLongPress}
             open={menuOpen}
             onCloseRequest={closeMenu}
             renderLabel={renderLabel}

--- a/src/routes/MetaDetails/styles.less
+++ b/src/routes/MetaDetails/styles.less
@@ -57,6 +57,7 @@
             }
 
             .background-image {
+                pointer-events: none; 
                 display: block;
                 width: 100%;
                 height: 100%;


### PR DESCRIPTION
~~The context menu was not working on Firefox because the `contextmenu` event is not a PointerEvent on Firefox and we were using the pointerEvent property to check if it was from a mouse
https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event#browser_compatibility~~

~~The `contextmenu` event is managed by the browser, on desktop it should trigger on right click, on mobile on long press
So we don't really need to use the  `onLongPress` callback~~

We ended up using `mouseup` instead as it's a MouseEvent and check if right click was pressed
`onMouseUp` for desktop and `onLongPress` for mobile