### PR TITLE
fix error: "checker is not a function" in stream components

### DIFF
--- a/src/routes/MetaDetails/StreamsList/Stream/Stream.js
+++ b/src/routes/MetaDetails/StreamsList/Stream/Stream.js
@@ -123,48 +123,48 @@ Stream.propTypes = {
             fileName: PropTypes.string,
             streaming: PropTypes.string,
             openPlayer: PropTypes.shape({
-                choose: {
+                choose: PropTypes.shape({
                     ios: PropTypes.string,
                     android: PropTypes.string,
                     windows: PropTypes.string,
                     macos: PropTypes.string,
                     linux: PropTypes.string
-                },
-                vlc: {
+                }),
+                vlc: PropTypes.shape({
                     ios: PropTypes.string,
                     android: PropTypes.string,
                     windows: PropTypes.string,
                     macos: PropTypes.string,
                     linux: PropTypes.string
-                },
-                outplayer: {
+                }),
+                outplayer: PropTypes.shape({
                     ios: PropTypes.string,
                     android: PropTypes.string,
                     windows: PropTypes.string,
                     macos: PropTypes.string,
                     linux: PropTypes.string
-                },
-                infuse: {
+                }),
+                infuse: PropTypes.shape({
                     ios: PropTypes.string,
                     android: PropTypes.string,
                     windows: PropTypes.string,
                     macos: PropTypes.string,
                     linux: PropTypes.string
-                },
-                justplayer: {
+                }),
+                justplayer: PropTypes.shape({
                     ios: PropTypes.string,
                     android: PropTypes.string,
                     windows: PropTypes.string,
                     macos: PropTypes.string,
                     linux: PropTypes.string
-                },
-                mxplayer: {
+                }),
+                mxplayer: PropTypes.shape({
                     ios: PropTypes.string,
                     android: PropTypes.string,
                     windows: PropTypes.string,
                     macos: PropTypes.string,
                     linux: PropTypes.string
-                },
+                }),
             })
         })
     }),


### PR DESCRIPTION
wrap player objects inside PropTypes.shape() to define the object shape

error logs from google chrome's console: 
`Warning: Failed prop type: checker is not a function
    at Stream (webpack-internal:///./src/routes/MetaDetails/StreamsList/Stream/Stream.js:35:24)
    at StreamsList (webpack-internal:///./src/routes/MetaDetails/StreamsList/StreamsList.js:62:24)
    at div
    at div
    at MetaDetails (webpack-internal:///./src/routes/MetaDetails/MetaDetails.js:45:24)
    at Suspense
    at withCoreSuspender (webpack-internal:///./src/common/CoreSuspender.js:52:24)
    at div
    at ModalsContainerProvider (webpack-internal:///./src/router/ModalsContainerContext/ModalsContainerProvider.js:21:23)
    at div
    at Route (webpack-internal:///./src/router/Route/Route.js:10:23)
    at div
    at Router (webpack-internal:///./src/router/Router/Router.js:42:24)
    at withProtectedRoutes (webpack-internal:///./src/App/withProtectedRoutes.js:14:19)
    at Suspense
    at withCoreSuspender (webpack-internal:///./src/common/CoreSuspender.js:52:24)
    at ToastProvider (webpack-internal:///./src/common/Toast/ToastProvider.js:33:24)
    at ServicesProvider (webpack-internal:///./src/services/ServicesContext/ServicesProvider.js:9:28)
    at App (webpack-internal:///./src/App/App.js:55:25)`