### PR TITLE
add infuse player for ios

### DIFF
--- a/src/common/externalPlayerOptions.js
+++ b/src/common/externalPlayerOptions.js
@@ -7,7 +7,8 @@ let options = [{ label: 'EXTERNAL_PLAYER_DISABLED', value: 'internal' }];
 if (platform.name === 'ios') {
     options = options.concat([
         { label: 'VLC', value: 'vlc' },
-        { label: 'Outplayer', value: 'outplayer' }
+        { label: 'Outplayer', value: 'outplayer' },
+        { label: 'Infuse', value: 'infuse' }
     ]);
 } else if (platform.name === 'android') {
     options = options.concat([


### PR DESCRIPTION
Adds infuse to the list of external players for iOS. 

PR will resolve #463 