### PR TITLE
fix: webpack deprecation warning

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -152,7 +152,7 @@ module.exports = (env, argv) => ({
         host: '0.0.0.0',
         static: false,
         hot: false,
-        https: true,
+        server: 'https',
         liveReload: false
     },
     optimization: {


### PR DESCRIPTION
Fixes the warning:
```
setup initialize(node:2716221) [DEP_WEBPACK_DEV_SERVER_HTTPS] DeprecationWarning: 'https' option is deprecated. Please use the 'server' option.
```