### PR TITLE
fix: Player - new stream should not trigger multiple actions

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -340,14 +340,14 @@ const Player = ({ urlParams, queryParams }) => {
         dispatch({ type: 'setProp', propName: 'extraSubtitlesOutlineColor', propValue: settings.subtitlesOutlineColor });
     }, [settings.subtitlesOutlineColor]);
     React.useEffect(() => {
-        if (videoState.time !== null && !isNaN(videoState.time) &&
+        if (videoState.time !== null && !isNaN(videoState.time) && videoState.time !== 0 &&
             videoState.duration !== null && !isNaN(videoState.duration) &&
             videoState.manifest !== null && typeof videoState.manifest.name === 'string') {
             timeChanged(videoState.time, videoState.duration, videoState.manifest.name);
         }
     }, [videoState.time, videoState.duration, videoState.manifest]);
     React.useEffect(() => {
-        if (videoState.paused !== null) {
+        if (videoState.paused !== null && videoState.time !== null && !isNaN(videoState.time) && videoState.time !== 0) {
             pausedChanged(videoState.paused);
         }
     }, [videoState.paused]);


### PR DESCRIPTION
Fixes #523 

Maybe it would be better to have a boolean that skips the first pause and time changes from the Video player and set it to `true` after the initial skip.
This might solve the issue for continuing a stream too and not only for playing a new stream (where time = 0).