### PR TITLE
fix: remove search bar from addons route

### DIFF
--- a/src/common/NavBar/HorizontalNavBar/HorizontalNavBar.js
+++ b/src/common/NavBar/HorizontalNavBar/HorizontalNavBar.js
@@ -48,7 +48,7 @@ const HorizontalNavBar = React.memo(({ className, route, query, title, backButto
                     null
             }
             {
-                searchBar ?
+                searchBar && route !== 'addons' ?
                     <SearchBar className={styles['search-bar']} query={query} active={route === 'search'} />
                     :
                     null


### PR DESCRIPTION
## The search bar for movies and series will be removed from the add-ons route to not confuse users where to search for add-ons. 
<img width="1491" alt="Screenshot 2023-12-26 at 18 18 39" src="https://github.com/Stremio/stremio-web/assets/117831817/756c5c9c-5ca3-444e-a20b-1eb1ca154f7f">
