### PR TITLE
fix: search-history visibility

### DIFF
--- a/src/common/NavBar/HorizontalNavBar/SearchBar/SearchBar.js
+++ b/src/common/NavBar/HorizontalNavBar/SearchBar/SearchBar.js
@@ -23,7 +23,7 @@ const SearchBar = React.memo(({ className, query, active }) => {
     const localSearch = useLocalSearch();
     const { createTorrentFromMagnet } = useTorrent();
 
-    const [historyOpen, openHistory, closeHistory, ] = useBinaryState(false);
+    const [historyOpen, openHistory, closeHistory, ] = useBinaryState(query === null ? true : false);
     const [currentQuery, setCurrentQuery] = React.useState(query || '');
 
     const searchInputRef = React.useRef(null);


### PR DESCRIPTION
Now the search history opens right away if you click on the search bar from different route than search