### PR TITLE
fix: toasts padding on mobile

### DIFF
--- a/src/App/styles.less
+++ b/src/App/styles.less
@@ -178,5 +178,13 @@ html {
     html {
         min-width: inherit;
         min-height: inherit;
+
+        body {
+            :global(#app) {
+                .toasts-container {
+                    padding: 0 1rem;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## BEFORE
<img width="482" alt="Screenshot 2024-02-20 at 11 03 12" src="https://github.com/Stremio/stremio-web/assets/117831817/a01d6d3d-e270-4fc0-b591-7cd4555e4201">
## AFTER
<img width="549" alt="Screenshot 2024-02-20 at 11 05 29" src="https://github.com/Stremio/stremio-web/assets/117831817/ce1395ef-01f5-4949-8b66-14b6b38589ac">

