### PR TITLE
fix: metaitem titles overflow

### DIFF
--- a/src/common/MetaItem/styles.less
+++ b/src/common/MetaItem/styles.less
@@ -317,11 +317,15 @@
 
         .title-label {
             flex: 1;
-            max-height: 2.4em;
+            max-height: 2.6em;
             padding-left: 1.5rem;
             font-weight: 600;
             text-align: center;
             color: var(--primary-foreground-color);
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
 
             &:only-child {
                 padding: 0 0.5rem;

--- a/src/common/MetaItem/styles.less
+++ b/src/common/MetaItem/styles.less
@@ -317,7 +317,6 @@
 
         .title-label {
             flex: 1;
-            max-height: 2.6em;
             padding-left: 1.5rem;
             font-weight: 600;
             text-align: center;

--- a/src/common/MetaItem/styles.less
+++ b/src/common/MetaItem/styles.less
@@ -317,6 +317,7 @@
 
         .title-label {
             flex: 1;
+            max-height: 2.6em;
             padding-left: 1.5rem;
             font-weight: 600;
             text-align: center;

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -201,8 +201,6 @@ const Player = ({ urlParams, queryParams }) => {
             nextVideo();
 
             const deepLinks = player.nextVideo.deepLinks;
-            // eslint-disable-next-line no-console
-            console.log(deepLinks);
             if (deepLinks.metaDetailsStreams && deepLinks.player) {
                 window.location.replace(deepLinks.metaDetailsStreams);
                 window.location.href = deepLinks.player;
@@ -599,11 +597,6 @@ const Player = ({ urlParams, queryParams }) => {
             onPauseRequestedDebounced.cancel();
         };
     }, []);
-
-    // eslint-disable-next-line no-console
-    console.log(player);
-    // eslint-disable-next-line no-console
-    console.log(video);
 
     return (
         <div className={classnames(styles['player-container'], { [styles['overlayHidden']]: overlayHidden })}

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -201,6 +201,8 @@ const Player = ({ urlParams, queryParams }) => {
             nextVideo();
 
             const deepLinks = player.nextVideo.deepLinks;
+            // eslint-disable-next-line no-console
+            console.log(deepLinks);
             if (deepLinks.metaDetailsStreams && deepLinks.player) {
                 window.location.replace(deepLinks.metaDetailsStreams);
                 window.location.href = deepLinks.player;
@@ -597,6 +599,11 @@ const Player = ({ urlParams, queryParams }) => {
             onPauseRequestedDebounced.cancel();
         };
     }, []);
+
+    // eslint-disable-next-line no-console
+    console.log(player);
+    // eslint-disable-next-line no-console
+    console.log(video);
 
     return (
         <div className={classnames(styles['player-container'], { [styles['overlayHidden']]: overlayHidden })}


### PR DESCRIPTION
Fixed the issue where the second text line would be partially invisible and cut out, used line-clamp to limit the lines to max 2
