### PR TITLE
fix: allow scrollToBottom hook to trigger when there is no scroll bar

### DIFF
--- a/src/common/useOnScrollToBottom.js
+++ b/src/common/useOnScrollToBottom.js
@@ -5,7 +5,8 @@ const React = require('react');
 const useOnScrollToBottom = (cb, threshold = 0) => {
     const triggeredRef = React.useRef(false);
     const onScroll = React.useCallback((event) => {
-        if (event.target.scrollTop + event.target.clientHeight >= event.target.scrollHeight - threshold) {
+        if (event.target.scrollTop + event.target.clientHeight >= event.target.scrollHeight - threshold || 
+            event.target.clientHeight >= event.target.scrollHeight) {
             if (!triggeredRef.current) {
                 triggeredRef.current = true;
                 if (typeof cb === 'function') {


### PR DESCRIPTION
Hi there, just submitting this PR as I believe it should solve the issue [referenced here](https://github.com/Stremio/stremio-web/issues/539).

Unfortunately I don't have a large enough screen to be able to recreate this issue.

Updating the hook to also check for the target's height to be greater or equal to scroll height should also trigger cb.

I don't know whether you'd want this to be an optional param or whether you think it needs a bit more work.
This may cause more calls to this callback than you'd want if 'hasNextPage' is false and the screen remains unpopulated.