### PR TITLE
fix: metaitem watched indicator & new episode indicator styles

### DIFF
--- a/src/common/MetaItem/MetaItem.js
+++ b/src/common/MetaItem/MetaItem.js
@@ -74,7 +74,7 @@ const MetaItem = React.memo(({ className, type, name, poster, posterShape, poste
                         null
                 }
                 {
-                    !newVideos && watched ?
+                    watched ?
                         <div className={styles['watched-icon-layer']}>
                             <Icon className={styles['watched-icon']} name={'checkmark'} />
                         </div>

--- a/src/common/MetaItem/styles.less
+++ b/src/common/MetaItem/styles.less
@@ -129,7 +129,7 @@
         .watched-icon-layer {
             position: absolute;
             top: 0;
-            right: 0;
+            left: 0;
             display: flex;
             justify-content: center;
             align-items: center;


### PR DESCRIPTION
### Fixes:

1.  Moved the watched indicator to the left so both the watched indicator and new episode indicator might be visible