### PR TITLE
fix: support http streaming server URLs

### DIFF
--- a/http_server.js
+++ b/http_server.js
@@ -16,6 +16,9 @@ express().use(express.static(build_path, {
     setHeaders: (res, path) => {
         if (path === index_path) res.set('cache-control', `public, max-age: ${INDEX_CACHE}`);
         else res.set('cache-control', `public, max-age: ${ASSETS_CACHE}`);
+
+        // allow using a streaming server URL that uses http, like for when hosting a streaming server on a local network
+        res.set('Content-Security-Policy', 'upgrade-insecure-requests');
     }
 })).all('*', (_req, res) => {
     // TODO: better 404 page


### PR DESCRIPTION
Currently, if you try to set a streaming server URL to a URL on the local network from another machine, you'd have to use http and not https, but setting a http url as a streaming server URL on `https://web.stremio.com/#/settings` results in the following error:
`
stremio_core_web.js:416 Mixed Content: The page at 'https://web.stremio.com/500c80d…/scripts/worker.js' was loaded over HTTPS, but requested an insecure resource 'http://192.168.2.10:11470/device-info'. This request has been blocked; the content must be served over HTTPS.
`

This PR fixes that by allowing the use of a http resource from Stremio web server over https.

This would make it much easier to setup a machine on the local network as a streaming server and use it from Stremio web installed as a PWA on another device.