### PR TITLE
Fix/deploy on staging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+# Check for outdated actions
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install NPM dependencies
         run: npm ci
       - name: Build
@@ -19,10 +19,15 @@ jobs:
         run: npm test
       - name: Lint
         run: npm run lint
+      # Create recursivelly the destiantion dir with
+      # "--parrents where no error if existing, make parent directories as needed."
+      - run: mkdir -p ./build/${{ github.ref_name }}
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+          # in stremio, we use `feat/features-name` or `fix/this-bug`
+          # so we need a recursive creation of the destination dir
           destination_dir: ${{ github.ref_name }}
           allow_empty_commit: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,12 @@
 name: Build
 
 on:
+
   push:
     branches:
       - '**'
+  # Allow manual dispatch in GH
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Working with branches that contain path separator (in URL) are now supported.

Going to https://stremio.github.io/stremio-web/fix/deploy-on-staging/ should point to the latest branch build in web deployed in GH pages.