### PR TITLE
Proxy streams enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@stremio/stremio-colors": "5.0.1",
                 "@stremio/stremio-core-web": "0.47.7",
                 "@stremio/stremio-icons": "5.2.0",
-                "@stremio/stremio-video": "0.0.38",
+                "@stremio/stremio-video": "0.0.44",
                 "a-color-picker": "1.2.1",
                 "bowser": "2.11.0",
                 "buffer": "6.0.3",
@@ -3000,9 +3000,9 @@
             "integrity": "sha512-rABlPBTFF17QcSm/4IizVoE/jh+REt+waqA0RvIxuGjQppXlvj7CalqVvTam0CC2wgY00zNG1v/9kVHUDVzo4Q=="
         },
         "node_modules/@stremio/stremio-video": {
-            "version": "0.0.38",
-            "resolved": "https://registry.npmjs.org/@stremio/stremio-video/-/stremio-video-0.0.38.tgz",
-            "integrity": "sha512-ev9z3YdMcZAsTQjEwOLfqB9EI8GdbQzwSGMZIOLPR/7/Ce7BQIctwDnEtTLgPmCsRpYZsqOD1PiBwU9tiDHZ8w==",
+            "version": "0.0.44",
+            "resolved": "https://registry.npmjs.org/@stremio/stremio-video/-/stremio-video-0.0.44.tgz",
+            "integrity": "sha512-cDwUSbNTR6VpHJiREHR/lRiIgLUO4KFKqHn1oIQeA/EF5guqL0x4omhUZq7mcEfLHwdlgDZ7vChDd4TbkJ6z+Q==",
             "dependencies": {
                 "buffer": "6.0.3",
                 "color": "4.2.3",
@@ -3014,7 +3014,7 @@
                 "magnet-uri": "6.2.0",
                 "url": "0.11.0",
                 "video-name-parser": "1.4.6",
-                "vtt.js": "github:jaruba/vtt.js#e4f5f5603730866bacb174a93f51b734c9f29e6a"
+                "vtt.js": "github:jaruba/vtt.js#84d33d157848407d790d78423dacc41a096294f0"
             }
         },
         "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -13506,8 +13506,8 @@
         },
         "node_modules/vtt.js": {
             "version": "0.13.0",
-            "resolved": "git+ssh://git@github.com/jaruba/vtt.js.git#e4f5f5603730866bacb174a93f51b734c9f29e6a",
-            "integrity": "sha512-RXV60lPGrmjuRcV/jRuydLC2thMaMlmK4Vc3DtBmVSotFA3986sgW0H5AH9IUmHzQo4bFR2gELYLcfwVh7Dqow==",
+            "resolved": "git+ssh://git@github.com/jaruba/vtt.js.git#84d33d157848407d790d78423dacc41a096294f0",
+            "integrity": "sha512-N/WeijIW9oiGmfqWdEcNqSblzfnXR8dfsBRNPIG9YYFhIBU0Y2c7w8Sfl0bDOZVhjA5qHbwoHx6SxDgRLiraTQ==",
             "license": "Apache-2.0"
         },
         "node_modules/w3c-hr-time": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/runtime": "7.16.0",
                 "@sentry/browser": "6.13.3",
                 "@stremio/stremio-colors": "5.0.1",
-                "@stremio/stremio-core-web": "0.47.2",
+                "@stremio/stremio-core-web": "0.47.7",
                 "@stremio/stremio-icons": "5.2.0",
                 "@stremio/stremio-video": "0.0.38",
                 "a-color-picker": "1.2.1",
@@ -2971,9 +2971,9 @@
             "license": "MIT"
         },
         "node_modules/@stremio/stremio-core-web": {
-            "version": "0.47.2",
-            "resolved": "https://registry.npmjs.org/@stremio/stremio-core-web/-/stremio-core-web-0.47.2.tgz",
-            "integrity": "sha512-kJXkshXT5f5go137id9MHrVA7PfHao2pGSxfEBbMDGFCqAVfF4jRFTXmfLC0cS1R+EjYhajUrSsXnEddtb2c7g==",
+            "version": "0.47.7",
+            "resolved": "https://registry.npmjs.org/@stremio/stremio-core-web/-/stremio-core-web-0.47.7.tgz",
+            "integrity": "sha512-3hTie3Yx6198TY1rS2fdA5HKPmejqTDbE8C05+HdqM6oXor9TXVoSjY9AMPlSVUJvu40sP3oeenhe2MRBUQizw==",
             "dependencies": {
                 "@babel/runtime": "7.24.1"
             }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@babel/runtime": "7.16.0",
         "@sentry/browser": "6.13.3",
         "@stremio/stremio-colors": "5.0.1",
-        "@stremio/stremio-core-web": "0.47.2",
+        "@stremio/stremio-core-web": "0.47.7",
         "@stremio/stremio-icons": "5.2.0",
         "@stremio/stremio-video": "0.0.38",
         "a-color-picker": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "@stremio/stremio-colors": "5.0.1",
         "@stremio/stremio-core-web": "0.47.7",
         "@stremio/stremio-icons": "5.2.0",
-        "@stremio/stremio-video": "0.0.38",
+        "@stremio/stremio-video": "0.0.44",
         "a-color-picker": "1.2.1",
         "bowser": "2.11.0",
         "buffer": "6.0.3",

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -292,6 +292,7 @@ const Player = ({ urlParams, queryParams }) => {
                     0,
                 forceTranscoding: forceTranscoding || casting,
                 maxAudioChannels: settings.surroundSound ? 32 : 2,
+                streamingServerSettings: streamingServer.settings.content,
                 streamingServerURL: streamingServer.baseUrl ?
                     casting ?
                         streamingServer.baseUrl

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -292,7 +292,7 @@ const Player = ({ urlParams, queryParams }) => {
                     0,
                 forceTranscoding: forceTranscoding || casting,
                 maxAudioChannels: settings.surroundSound ? 32 : 2,
-                streamingServerSettings: streamingServer.settings.content,
+                streamingServerSettings: streamingServer.settings.type === 'Ready' ? streamingServer.settings.content : null,
                 streamingServerURL: streamingServer.baseUrl ?
                     casting ?
                         streamingServer.baseUrl

--- a/src/routes/Settings/Settings.js
+++ b/src/routes/Settings/Settings.js
@@ -47,6 +47,7 @@ const Settings = () => {
     } = useProfileSettingsInputs(profile);
     const {
         streamingServerRemoteUrlInput,
+        proxyStreamsCheckbox,
         remoteEndpointSelect,
         cacheSizeSelect,
         torrentProfileSelect,
@@ -622,6 +623,21 @@ const Settings = () => {
                                     <Multiselect
                                         className={classnames(styles['option-input-container'], styles['multiselect-container'])}
                                         {...transcodingProfileSelect}
+                                    />
+                                </div>
+                                :
+                                null
+                        }
+                        {
+                            proxyStreamsCheckbox !== null ?
+                                <div className={styles['option-container']}>
+                                    <div className={styles['option-name-container']}>
+                                        <div className={styles['label']}>{ t('SETTINGS_PROXY_STREAMS') }</div>
+                                    </div>
+                                    <Checkbox
+                                        className={classnames(styles['option-input-container'], styles['checkbox-container'])}
+                                        tabIndex={-1}
+                                        {...proxyStreamsCheckbox}
                                     />
                                 </div>
                                 :

--- a/src/routes/Settings/useStreamingServerSettingsInputs.js
+++ b/src/routes/Settings/useStreamingServerSettingsInputs.js
@@ -80,7 +80,7 @@ const useStreamingServerSettingsInputs = (streamingServer) => {
                     }
                 });
             }
-        }
+        };
     }, [streamingServer.settings]);
 
     const remoteEndpointSelect = React.useMemo(() => {

--- a/src/routes/Settings/useStreamingServerSettingsInputs.js
+++ b/src/routes/Settings/useStreamingServerSettingsInputs.js
@@ -61,6 +61,28 @@ const useStreamingServerSettingsInputs = (streamingServer) => {
         value: streamingServer.remoteUrl,
     }), [streamingServer.remoteUrl]);
 
+    const proxyStreamsCheckbox = React.useMemo(() => {
+        if (streamingServer.settings?.type !== 'Ready') {
+            return null;
+        }
+
+        return {
+            checked: streamingServer.settings.content.proxyStreamsEnabled,
+            onClick: () => {
+                core.transport.dispatch({
+                    action: 'StreamingServer',
+                    args: {
+                        action: 'UpdateSettings',
+                        args: {
+                            ...streamingServer.settings.content,
+                            proxyStreamsEnabled: !streamingServer.settings.content.proxyStreamsEnabled
+                        }
+                    }
+                });
+            }
+        }
+    }, [streamingServer.settings]);
+
     const remoteEndpointSelect = React.useMemo(() => {
         if (streamingServer.settings?.type !== 'Ready' || streamingServer.networkInfo?.type !== 'Ready') {
             return null;
@@ -198,7 +220,7 @@ const useStreamingServerSettingsInputs = (streamingServer) => {
             }
         };
     }, [streamingServer.settings, streamingServer.deviceInfo]);
-    return { streamingServerRemoteUrlInput, remoteEndpointSelect, cacheSizeSelect, torrentProfileSelect, transcodingProfileSelect };
+    return { streamingServerRemoteUrlInput, proxyStreamsCheckbox, remoteEndpointSelect, cacheSizeSelect, torrentProfileSelect, transcodingProfileSelect };
 };
 
 module.exports = useStreamingServerSettingsInputs;


### PR DESCRIPTION
can be tested at https://stremio.github.io/stremio-web/proxy_streams_enabled/
if server settings proxy_streams_enabled is true, then it will proxy all url streams through the /proxy endpoint of that server, regardless of the stream behavior hints.
if server settings proxy_streams_enabled is false, then the stream will be proxied only if there is a behavior hint `proxyHeaders`