### PR TITLE
feat: Introduce IMDb Rating on Card View

### DIFF
--- a/src/common/MetaItem/MetaItem.js
+++ b/src/common/MetaItem/MetaItem.js
@@ -211,7 +211,7 @@ MetaItem.propTypes = {
         category: PropTypes.string,
         name: PropTypes.string,
         url: PropTypes.string
-    })),
+    }))
 };
 
 module.exports = MetaItem;

--- a/src/common/MetaItem/MetaItem.js
+++ b/src/common/MetaItem/MetaItem.js
@@ -12,10 +12,32 @@ const Multiselect = require('stremio/common/Multiselect');
 const useBinaryState = require('stremio/common/useBinaryState');
 const { ICON_FOR_TYPE } = require('stremio/common/CONSTANTS');
 const styles = require('./styles');
+const UrlUtils = require('url');
+const CONSTANTS = require('stremio/common/CONSTANTS');
 
-const MetaItem = React.memo(({ className, type, name, poster, posterShape, posterChangeCursor, progress, newVideos, options, deepLinks, dataset, optionOnSelect, onDismissClick, onPlayClick, watched, ...props }) => {
+const MetaItem = React.memo(({ className, type, name, poster, links, posterShape, posterChangeCursor, progress, newVideos, options, deepLinks, dataset, optionOnSelect, onDismissClick, onPlayClick, watched, ...props }) => {
     const { t } = useTranslation();
     const [menuOpen, onMenuOpen, onMenuClose] = useBinaryState(false);
+    const imdbLink = React.useMemo(() => {
+        if (!Array.isArray(links)) {
+            return null;
+        }
+
+        const imdbLink = links.find((link) => {
+            if (!link || typeof link.category !== 'string' || typeof link.url !== 'string') {
+                return false;
+            }
+
+            const { hostname } = UrlUtils.parse(link.url);
+            return link.category === CONSTANTS.IMDB_LINK_CATEGORY && hostname === 'imdb.com';
+        });
+
+        return imdbLink ? {
+            label: imdbLink.name,
+            href: `https://www.stremio.com/warning#${encodeURIComponent(imdbLink.url)}`
+        } : null;
+    }, [links]);
+
     const href = React.useMemo(() => {
         return deepLinks ?
             typeof deepLinks.player === 'string' ?
@@ -131,6 +153,15 @@ const MetaItem = React.memo(({ className, type, name, poster, posterShape, poste
                             {typeof name === 'string' && name.length > 0 ? name : ''}
                         </div>
                         {
+                            imdbLink ?
+                                <div className={styles['imdb-button-container']}>
+                                    <Icon className={styles['icon']} name={'imdb'} />
+                                    <div className={styles['label']}>{imdbLink.label}</div>
+                                </div>
+                                :
+                                null
+                        }
+                        {
                             Array.isArray(options) && options.length > 0 ?
                                 <Multiselect
                                     className={styles['menu-label-container']}
@@ -175,7 +206,12 @@ MetaItem.propTypes = {
     onDismissClick: PropTypes.func,
     onPlayClick: PropTypes.func,
     onClick: PropTypes.func,
-    watched: PropTypes.bool
+    watched: PropTypes.bool,
+    links: PropTypes.arrayOf(PropTypes.shape({
+        category: PropTypes.string,
+        name: PropTypes.string,
+        url: PropTypes.string
+    })),
 };
 
 module.exports = MetaItem;

--- a/src/common/MetaItem/MetaItem.js
+++ b/src/common/MetaItem/MetaItem.js
@@ -15,7 +15,7 @@ const styles = require('./styles');
 const UrlUtils = require('url');
 const CONSTANTS = require('stremio/common/CONSTANTS');
 
-const MetaItem = React.memo(({ className, type, name, poster, links, posterShape, posterChangeCursor, progress, newVideos, options, deepLinks, dataset, optionOnSelect, onDismissClick, onPlayClick, watched, ...props }) => {
+const MetaItem = React.memo(({ className, type, name, poster, posterShape, posterChangeCursor, progress, newVideos, options, deepLinks, dataset, optionOnSelect, onDismissClick, onPlayClick, watched, links, ...props }) => {
     const { t } = useTranslation();
     const [menuOpen, onMenuOpen, onMenuClose] = useBinaryState(false);
     const imdbLink = React.useMemo(() => {

--- a/src/common/MetaItem/styles.less
+++ b/src/common/MetaItem/styles.less
@@ -375,6 +375,31 @@
             }
         }
     }
+
+    .imdb-button-container {
+        flex: 0 1 auto;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        border-radius: 2.5rem;
+        margin-left: 1rem;
+
+        .label {
+            flex: auto;
+            // margin-right: 1rem;
+            font-size: 0.8rem;
+            font-weight: 500;
+            color: var(--primary-foreground-color);
+        }
+
+        .icon {
+            flex: auto;
+            width: 2rem;
+            height: 2rem;
+            color: var(--color-imdb);
+        }
+    }
 }
 
 @media only screen and (max-width: @minimum) {
@@ -384,5 +409,9 @@
         .title-bar-container {
             margin-top: 0.5rem;
         }
+
+        .imdb-button-container {
+            display: none;
+        }        
     }
 }

--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -146,6 +146,7 @@ const Discover = ({ urlParams, queryParams }) => {
                                                 className={classnames({ 'selected': selectedMetaItemIndex === index })}
                                                 type={metaItem.type}
                                                 name={metaItem.name}
+                                                links={metaItem.links}
                                                 poster={metaItem.poster}
                                                 posterShape={metaItem.posterShape}
                                                 playname={selectedMetaItemIndex === index}

--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -146,7 +146,6 @@ const Discover = ({ urlParams, queryParams }) => {
                                                 className={classnames({ 'selected': selectedMetaItemIndex === index })}
                                                 type={metaItem.type}
                                                 name={metaItem.name}
-                                                links={metaItem.links}
                                                 poster={metaItem.poster}
                                                 posterShape={metaItem.posterShape}
                                                 playname={selectedMetaItemIndex === index}


### PR DESCRIPTION
Hi, 

As an iOS user (web.stremio.com on PWA), I would love to view the IMDb ratings on the home screen along with the movie title. 
This simple change introduces the rating next to the title.
Note:
- Only enabled on the Home/Board Tab, as Discovery tab already has this in preview side pane.
- Disabled on small screen/mobile devices, as title gets shortened and illegible when this is introduced on small screens.

Before I continue developing this further, just want to check if this is something that could be considered for introducing to the platform? I am aware that there is RPDB but that is a paid option, and this IMDb rating is already present in current props.

If this sounds like a feasible idea, here are the further action items (in priority) that could be worked on before shipping:
- [x] Introduce the slot for rating next to title
- [ ] Allow user to turn this feature on/off from settings
- [ ] Allow user to place single slot on left or right of title
- [ ] Allow user to select between runtime/release year/IMDb rating to display in the slot OR display all 3 just above the title
- [ ] Consider supporting Rotten Tomatoes/TMDB/Metacritic integration in the future

Feature Screenshots:
| Feature | Production |
|---------|------------|
| ![image](https://github.com/user-attachments/assets/89fa2da2-548c-45cc-8abf-24dc9c43f481) | ![image](https://github.com/user-attachments/assets/8a159d57-0412-4e05-8c66-160823cce715) |

