### PR TITLE
feat: Introduce Hide/Show option for each row

### DIFF
--- a/src/common/MetaRow/MetaRow.js
+++ b/src/common/MetaRow/MetaRow.js
@@ -13,6 +13,7 @@ const styles = require('./styles');
 
 const MetaRow = ({ className, title, catalog, message, itemComponent, notifications }) => {
     const t = useTranslate();
+    const [isHidden, setIsHidden] = React.useState(false);
 
     const catalogTitle = React.useMemo(() => {
         return title ?? t.catalogTitle(catalog);
@@ -37,10 +38,16 @@ const MetaRow = ({ className, title, catalog, message, itemComponent, notificati
                 }
                 {
                     href ?
-                        <Button className={styles['see-all-container']} title={t.string('BUTTON_SEE_ALL')} href={href} tabIndex={-1}>
-                            <div className={styles['label']}>{ t.string('BUTTON_SEE_ALL') }</div>
-                            <Icon className={styles['icon']} name={'chevron-forward'} />
-                        </Button>
+                        <div className={styles['meta-row-actions-container']}>
+                            <Button className={styles['see-all-container']} onClick={() => setIsHidden(!isHidden)}>
+                                <div className={styles['label']}>{isHidden ? 'Show' : 'Hide'}</div>
+                                <Icon className={styles['icon']} name={isHidden ? 'eye' : 'eye-off'} />
+                            </Button>
+                            <Button className={styles['see-all-container']} title={t.string('BUTTON_SEE_ALL')} href={href} tabIndex={-1}>
+                                <div className={styles['label']}>{t.string('BUTTON_SEE_ALL')}</div>
+                                <Icon className={styles['icon']} name={'chevron-forward'} />
+                            </Button>
+                        </div>
                         :
                         null
                 }
@@ -49,7 +56,7 @@ const MetaRow = ({ className, title, catalog, message, itemComponent, notificati
                 typeof message === 'string' && message.length > 0 ?
                     <div className={styles['message-container']} title={message}>{message}</div>
                     :
-                    <div className={styles['meta-items-container']}>
+                    !isHidden && <div className={styles['meta-items-container']}>
                         {
                             ReactIs.isValidElementType(itemComponent) ?
                                 items.slice(0, CONSTANTS.CATALOG_PREVIEW_SIZE).map((item, index) => {

--- a/src/common/MetaRow/styles.less
+++ b/src/common/MetaRow/styles.less
@@ -84,6 +84,11 @@
             }
         }
     }
+
+    .meta-row-actions-container {
+        display: flex;
+        flex-direction: row;
+    }
 }
 
 @media only screen and (max-width: @minimum) {


### PR DESCRIPTION
Introducing a small change that adds the option to hide unwanted rows during a browsing session on Stremio.
Sometimes for users with too many add-ons, it becomes a chore to scroll through unwanted rows of content that the user does not want. A simple solution to this is to temporarily hide the content-row and give user the control.

Feature demo:
![ezgif-6-02fef43591](https://github.com/user-attachments/assets/386d3af1-c6f3-4929-9a75-2f14f670120c)

Other related features/improvements that may be considered in the future:
- [x] Ability to show/hide rows and persist during session
- [ ] Ability to permanently hide row, this may be combined with the ability to re-order addons as per user's preference
- [ ] Store state and persist outside session (maybe as a setting stored on user profile) and sync across all devices
- [ ] Add animations to provider a smoother user experience.
