### PR TITLE
fix: Streaming server settings - use empty string instead of null for remoteHttps

### DIFF
--- a/src/routes/Settings/useStreamingServerSettingsInputs.js
+++ b/src/routes/Settings/useStreamingServerSettingsInputs.js
@@ -70,7 +70,7 @@ const useStreamingServerSettingsInputs = (streamingServer) => {
             options: [
                 {
                     label: t('SETTINGS_DISABLED'),
-                    value: null,
+                    value: '',
                 },
                 ...streamingServer.networkInfo.content.availableInterfaces.map((address) => ({
                     label: address,


### PR DESCRIPTION
Adds the UI fix for the core's change to use empty string instead of `null`. This is in-par with Desktop and it will now use the same options on web and Desktop.

Needs core: https://github.com/Stremio/stremio-core/pull/702