### PR TITLE
fix(MetaDetails): list container overflow on mobile

### DIFF
--- a/src/routes/MetaDetails/StreamsList/styles.less
+++ b/src/routes/MetaDetails/StreamsList/styles.less
@@ -182,6 +182,7 @@
 
         .streams-container {
             margin-top: 0;
+            overflow: visible;
             scrollbar-color: @color-surface-light5-20 transparent;
 
             &::-webkit-scrollbar-thumb {

--- a/src/routes/MetaDetails/VideosList/styles.less
+++ b/src/routes/MetaDetails/VideosList/styles.less
@@ -74,5 +74,9 @@
 @media only screen and (max-width: @minimum) {
     .videos-list-container {
         overflow: visible;
+
+        .videos-container {
+            overflow: auto;
+        }
     }
 }


### PR DESCRIPTION
Fix overflow of videos and streams container, allowing the context menu to display correctly