### PR TITLE
feat: MetaDetails back button behavior

### DIFF
--- a/src/routes/MetaDetails/StreamsList/StreamsList.js
+++ b/src/routes/MetaDetails/StreamsList/StreamsList.js
@@ -20,8 +20,17 @@ const StreamsList = ({ className, video, ...props }) => {
         setSelectedAddon(event.value);
     }, []);
     const backButtonOnClick = React.useCallback(() => {
-        window.history.back();
-    }, []);
+        if (video.deepLinks && typeof video.deepLinks.metaDetailsVideos === 'string') {
+            window.location.replace(video.deepLinks.metaDetailsVideos + (
+                typeof video.season === 'number' ?
+                    `?${new URLSearchParams({'season': video.season})}`
+                    :
+                    null
+                ));
+        } else {
+            window.history.back();
+        }
+    }, [video]);
     const countLoadingAddons = React.useMemo(() => {
         return props.streams.filter((stream) => stream.content.type === 'Loading').length;
     }, [props.streams]);
@@ -78,6 +87,30 @@ const StreamsList = ({ className, video, ...props }) => {
     }, [streamsByAddon, selectedAddon]);
     return (
         <div className={classnames(className, styles['streams-list-container'])}>
+            <div className={styles['select-choices-wrapper']}>
+                {
+                    video ?
+                        <React.Fragment>
+                            <Button className={classnames(styles['button-container'], styles['back-button-container'])} tabIndex={-1} onClick={backButtonOnClick}>
+                                <Icon className={styles['icon']} name={'chevron-back'} />
+                            </Button>
+                            <div className={styles['episode-title']}>
+                                {`S${video?.season}E${video?.episode} ${(video?.title)}`}
+                            </div>
+                        </React.Fragment>
+                        :
+                        null
+                }
+                {
+                    Object.keys(streamsByAddon).length > 1 ?
+                        <Multiselect
+                            {...selectableOptions}
+                            className={styles['select-input-container']}
+                        />
+                        :
+                        null
+                }
+            </div>
             {
                 props.streams.length === 0 ?
                     <div className={styles['message-container']}>
@@ -109,30 +142,6 @@ const StreamsList = ({ className, video, ...props }) => {
                                         :
                                         null
                                 }
-                                <div className={styles['select-choices-wrapper']}>
-                                    {
-                                        video ?
-                                            <React.Fragment>
-                                                <Button className={classnames(styles['button-container'], styles['back-button-container'])} tabIndex={-1} onClick={backButtonOnClick}>
-                                                    <Icon className={styles['icon']} name={'chevron-back'} />
-                                                </Button>
-                                                <div className={styles['episode-title']}>
-                                                    {`S${video?.season}E${video?.episode} ${(video?.title)}`}
-                                                </div>
-                                            </React.Fragment>
-                                            :
-                                            null
-                                    }
-                                    {
-                                        Object.keys(streamsByAddon).length > 1 ?
-                                            <Multiselect
-                                                {...selectableOptions}
-                                                className={styles['select-input-container']}
-                                            />
-                                            :
-                                            null
-                                    }
-                                </div>
                                 <div className={styles['streams-container']}>
                                     {filteredStreams.map((stream, index) => (
                                         <Stream

--- a/src/routes/MetaDetails/StreamsList/StreamsList.js
+++ b/src/routes/MetaDetails/StreamsList/StreamsList.js
@@ -26,7 +26,7 @@ const StreamsList = ({ className, video, ...props }) => {
                     `?${new URLSearchParams({'season': video.season})}`
                     :
                     null
-                ));
+            ));
         } else {
             window.history.back();
         }

--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -56,17 +56,14 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             }
         });
     }, [id, released, watched]);
-    const href = React.useMemo(() => {
-        return deepLinks ?
-            typeof deepLinks.player === 'string' ?
-                deepLinks.player
-                :
-                typeof deepLinks.metaDetailsStreams === 'string' ?
-                    deepLinks.metaDetailsStreams
-                    :
-                    null
-            :
-            null;
+    const videoButtonOnClick = React.useCallback(() => {
+        if (deepLinks) {
+            if (typeof deepLinks.player === 'string') {
+                window.location = deepLinks.player;
+            } else if (typeof deepLinks.metaDetailsStreams === 'string') {
+                window.location.replace(deepLinks.metaDetailsStreams);
+            }
+        }
     }, [deepLinks]);
     const renderLabel = React.useMemo(() => function renderLabel({ className, id, title, thumbnail, episode, released, upcoming, watched, progress, scheduled, children, ...props }) {
         return (
@@ -171,7 +168,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
             watched={watched}
             progress={progress}
             scheduled={scheduled}
-            href={href}
+            onClick={videoButtonOnClick}
             {...props}
             onMouseUp={popupLabelOnMouseUp}
             onLongPress={popupLabelOnLongPress}


### PR DESCRIPTION
The back button on the StreamsList will now bring the user back to the VideoList with respect for the video's season when possible.

Moved "select-choices-wrapper" up in the "streams-list-container" to avoid trapping the user in StreamsList if no Streams are available.

Video Buttons on the VideoList now use an onClick callback that utilizes "window.location.replace" to navigate to the StreamsList rather than "href". This allows the back button on the HorizontalNavBar to bring the user back to whatever library they came from more consistently (rather than just navigating around MetaDetails.)