### PR TITLE
feat: Add label to subtitle tracks

### DIFF
--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -204,14 +204,13 @@ const SubtitlesMenu = React.memo((props) => {
                         <div className={styles['variants-list']}>
                             {subtitlesTracksForLanguage.map((track, index) => (
                                 <Button key={index} title={track.label} className={classnames(styles['variant-option'], { 'selected': props.selectedSubtitlesTrackId === track.id || props.selectedExtraSubtitlesTrackId === track.id })} data-id={track.id} data-origin={track.origin} data-embedded={track.embedded} onClick={subtitlesTrackOnClick}>
-                                    <div className={styles['variant-origin']}>
-                                        {track.origin}
-                                        {
-                                            typeof track.label === 'string' && !track.label.startsWith('http') ?
-                                                <div className={styles['variant-label']}>{track.label}</div>
-                                                :
-                                                null
+                                    <div className={styles['variant-label']}>
+                                        {typeof track.label === 'string' && !track.label.startsWith('http') ?
+                                            track.label
+                                            :
+                                            track.lang
                                         }
+                                        <div className={styles['variant-origin']}>{t(track.origin)}</div>
                                     </div>
                                     {
                                         props.selectedSubtitlesTrackId === track.id || props.selectedExtraSubtitlesTrackId === track.id ?

--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -205,10 +205,11 @@ const SubtitlesMenu = React.memo((props) => {
                             {subtitlesTracksForLanguage.map((track, index) => (
                                 <Button key={index} title={track.label} className={classnames(styles['variant-option'], { 'selected': props.selectedSubtitlesTrackId === track.id || props.selectedExtraSubtitlesTrackId === track.id })} data-id={track.id} data-origin={track.origin} data-embedded={track.embedded} onClick={subtitlesTrackOnClick}>
                                     <div className={styles['variant-label']}>
-                                        {typeof track.label === 'string' && !track.label.startsWith('http') ?
-                                            track.label
-                                            :
-                                            track.lang
+                                        {
+                                            typeof track.label === 'string' && !track.label.startsWith('http') ?
+                                                track.label
+                                                :
+                                                track.lang
                                         }
                                         <div className={styles['variant-origin']}>{t(track.origin)}</div>
                                     </div>

--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -206,7 +206,12 @@ const SubtitlesMenu = React.memo((props) => {
                                 <Button key={index} title={track.label} className={classnames(styles['variant-option'], { 'selected': props.selectedSubtitlesTrackId === track.id || props.selectedExtraSubtitlesTrackId === track.id })} data-id={track.id} data-origin={track.origin} data-embedded={track.embedded} onClick={subtitlesTrackOnClick}>
                                     <div className={styles['variant-origin']}>
                                         {track.origin}
-                                        <div className={styles['variant-label']}>{track.label}</div>
+                                        {
+                                            typeof track.label === 'string' && !track.label.startsWith('http') ?
+                                                <div className={styles['variant-label']}>{track.label}</div>
+                                                :
+                                                null
+                                        }
                                     </div>
                                     {
                                         props.selectedSubtitlesTrackId === track.id || props.selectedExtraSubtitlesTrackId === track.id ?

--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -204,7 +204,10 @@ const SubtitlesMenu = React.memo((props) => {
                         <div className={styles['variants-list']}>
                             {subtitlesTracksForLanguage.map((track, index) => (
                                 <Button key={index} title={track.label} className={classnames(styles['variant-option'], { 'selected': props.selectedSubtitlesTrackId === track.id || props.selectedExtraSubtitlesTrackId === track.id })} data-id={track.id} data-origin={track.origin} data-embedded={track.embedded} onClick={subtitlesTrackOnClick}>
-                                    <div className={styles['variant-label']}>{track.origin}</div>
+                                    <div className={styles['variant-origin']}>
+                                        {track.origin}
+                                        <div className={styles['variant-label']}>{track.label}</div>
+                                    </div>
                                     {
                                         props.selectedSubtitlesTrackId === track.id || props.selectedExtraSubtitlesTrackId === track.id ?
                                             <div className={styles['icon']} />

--- a/src/routes/Player/SubtitlesMenu/styles.less
+++ b/src/routes/Player/SubtitlesMenu/styles.less
@@ -40,14 +40,16 @@
                     background-color: var(--overlay-color);
                 }
 
-                .language-label, .variant-origin {
+                .language-label, .variant-label {
                     flex: 1;
                     max-height: 2.4em;
                     font-size: 1.1rem;
+                    text-wrap: nowrap;
+                    text-overflow: ellipsis;
                     color: var(--primary-foreground-color);
                 }
 
-                .variant-origin .variant-label {
+                .variant-label .variant-origin {
                     color: var(--color-placeholder-text);
                 }
 

--- a/src/routes/Player/SubtitlesMenu/styles.less
+++ b/src/routes/Player/SubtitlesMenu/styles.less
@@ -44,9 +44,12 @@
                     flex: 1;
                     max-height: 2.4em;
                     font-size: 1.1rem;
+                    color: var(--primary-foreground-color);
+                }
+
+                .language-label, .variant-label, .variant-origin {
                     text-wrap: nowrap;
                     text-overflow: ellipsis;
-                    color: var(--primary-foreground-color);
                 }
 
                 .variant-label .variant-origin {

--- a/src/routes/Player/SubtitlesMenu/styles.less
+++ b/src/routes/Player/SubtitlesMenu/styles.less
@@ -40,11 +40,15 @@
                     background-color: var(--overlay-color);
                 }
 
-                .language-label, .variant-label {
+                .language-label, .variant-origin {
                     flex: 1;
                     max-height: 2.4em;
                     font-size: 1.1rem;
                     color: var(--primary-foreground-color);
+                }
+
+                .variant-origin .variant-label {
+                    color: var(--color-placeholder-text);
                 }
 
                 .icon {


### PR DESCRIPTION
Small change to include the subtitle's label below it's origin in the subtitle variant list.

Before:
![Screen Shot 2024-09-22 at 00 20 25](https://github.com/user-attachments/assets/dd7923fc-d6a8-45d6-8f4a-e586d30d9250)

After:
![Screen Shot 2024-09-22 at 00 03 04](https://github.com/user-attachments/assets/b0e301a6-795d-4ac3-b1db-749665912be4)
