### PR TITLE
fix: scrollTop safari content issue

### DIFF
--- a/src/common/NavBar/VerticalNavBar/NavTabButton/NavTabButton.js
+++ b/src/common/NavBar/VerticalNavBar/NavTabButton/NavTabButton.js
@@ -20,7 +20,7 @@ const NavTabButton = ({ className, logo, icon, label, href, selected, onClick })
 
         scrollableElements.forEach((element) => {
             if (element.scrollTop > 0) {
-                element.scrollTop = 0;
+                element.scrollTo({ top: 0, behavior: 'smooth' });
             }
         });
     };


### PR DESCRIPTION
#677 feature had a bug that was causing the HTML to disappear on Safari when the content was still scrolling up / down and you have triggered the scroll Top function by double-clicking the navbar button