### PR TITLE
Fix for not being able to scroll seasons dropdown

### DIFF
--- a/src/routes/MetaDetails/VideosList/SeasonsBar/styles.less
+++ b/src/routes/MetaDetails/VideosList/SeasonsBar/styles.less
@@ -80,6 +80,11 @@
             max-height: calc(3.2rem * 7);
             overflow: auto;
         }
+
+        div[role="listbox"] {
+            max-height: calc(3.2rem * 10);
+            overflow: auto;
+        }
     }
 }
 
@@ -90,6 +95,10 @@
         .seasons-popup-label-container {
             .multiselect-menu-container {
                 max-height: calc(3.2rem * 3);
+            }
+            div[role="listbox"] {
+                max-height: calc(3.2rem * 5);
+                overflow: auto;
             }
         }
     }


### PR DESCRIPTION
Before: 

Seasons dropdown is clipped, can't scroll
![localhost_8080_](https://github.com/user-attachments/assets/ab7d15cc-98c7-4a4d-94a4-3ec0ef2d51bc)

After:
Can scroll now
![localhost_8080_ (1)](https://github.com/user-attachments/assets/3fc640a3-35f9-4082-bbd0-fd3cb601e06d)
On mobile
![localhost_8080_ (2)](https://github.com/user-attachments/assets/3b62fbc0-67d3-4cfc-a513-aec3b1e9194b)

