### PR TITLE
fix: dropdown scroll

### DIFF
--- a/src/common/MultiselectMenu/Dropdown/Dropdown.less
+++ b/src/common/MultiselectMenu/Dropdown/Dropdown.less
@@ -1,5 +1,7 @@
 // Copyright (C) 2017-2024 Smart code 203358507
 
+@import (reference) '~stremio/common/screen-sizes.less';
+
 .dropdown {
     background: var(--modal-background-color);
     display: none;
@@ -14,8 +16,8 @@
 
     &.open {
         display: block;
-        max-height: 50vh;
-        overflow: scroll;
+        max-height: calc(3.2rem * 10);
+        overflow: auto;
     }
 
     .back-button {
@@ -27,6 +29,14 @@
 
         .back-button-icon {
             width: 1.5rem;
+        }
+    }
+}
+
+@media only screen and (max-width: @minimum) {
+    .dropdown {
+        &.open {
+            max-height: calc(3.2rem * 7);
         }
     }
 }

--- a/src/common/MultiselectMenu/Dropdown/Dropdown.less
+++ b/src/common/MultiselectMenu/Dropdown/Dropdown.less
@@ -14,6 +14,8 @@
 
     &.open {
         display: block;
+        max-height: 50vh;
+        overflow: scroll;
     }
 
     .back-button {


### PR DESCRIPTION
The seasons picker dropdown wasn't scrollable, and it couldn't be accessed when there were more than 10 seasons.
