### PR TITLE
fix: modal dialog styles issues

### DIFF
--- a/src/common/ModalDialog/ModalDialog.js
+++ b/src/common/ModalDialog/ModalDialog.js
@@ -70,7 +70,7 @@ const ModalDialog = ({ className, title, buttons, children, dataset, onCloseRequ
                             :
                             null
                     }
-                    <div className={styles['modal-dialog-content']}>
+                    <div className={styles['body-container']}>
                         {children}
                     </div>
                     {

--- a/src/common/ModalDialog/styles.less
+++ b/src/common/ModalDialog/styles.less
@@ -67,6 +67,7 @@
         .modal-dialog-content {
             z-index: 1;
             position: relative;
+            overflow-y: auto;
 
             .title-container {
                 flex: 1 0 auto;
@@ -157,9 +158,11 @@
             z-index: 0;
             padding: 0 1.5rem;
 
-            .buttons-container {
-                flex-direction: column;
-                gap: 1rem;
+            .modal-dialog-content {
+                .buttons-container {
+                    flex-direction: column;
+                    gap: 1rem;
+                }
             }
         }
 

--- a/src/common/ModalDialog/styles.less
+++ b/src/common/ModalDialog/styles.less
@@ -79,7 +79,7 @@
                 color: var(--primary-foreground-color);
             }
 
-            .modal-dialog-content {
+            .body-container {
                 flex: 1;
                 align-self: stretch;
                 overflow-y: auto;


### PR DESCRIPTION
Fixes:

- [x] Content wasn't accessible when the addon info is too long
- [x] Button text wasn't visible on mobile because of mistake in class placement