### PR TITLE
Add disable addon feature

### DIFF
--- a/src/common/AddonDetailsModal/AddonDetailsModal.js
+++ b/src/common/AddonDetailsModal/AddonDetailsModal.js
@@ -1,5 +1,3 @@
-// Copyright (C) 2017-2023 Smart code 203358507
-
 const React = require('react');
 const PropTypes = require('prop-types');
 const ModalDialog = require('stremio/common/ModalDialog');
@@ -135,7 +133,57 @@ const AddonDetailsModal = ({ transportUrl, onCloseRequest }) => {
                 }
                 :
                 null;
-        return configureButton && toggleButton ? [cancelButton, configureButton, toggleButton] : configureButton ? [cancelButton, configureButton] : toggleButton ? [cancelButton, toggleButton] : [cancelButton];
+        const disableButton = addonDetails.localAddon !== null && !addonDetails.localAddon.disabled ?
+            {
+                className: styles['disable-button'],
+                label: 'Disable',
+                props: {
+                    onClick: (event) => {
+                        core.transport.dispatch({
+                            action: 'Ctx',
+                            args: {
+                                action: 'DisableAddon',
+                                args: addonDetails.localAddon
+                            }
+                        });
+                        if (typeof onCloseRequest === 'function') {
+                            onCloseRequest({
+                                type: 'disable',
+                                reactEvent: event,
+                                nativeEvent: event.nativeEvent
+                            });
+                        }
+                    }
+                }
+            }
+            :
+            null;
+        const enableButton = addonDetails.localAddon !== null && addonDetails.localAddon.disabled ?
+            {
+                className: styles['enable-button'],
+                label: 'Enable',
+                props: {
+                    onClick: (event) => {
+                        core.transport.dispatch({
+                            action: 'Ctx',
+                            args: {
+                                action: 'EnableAddon',
+                                args: addonDetails.localAddon
+                            }
+                        });
+                        if (typeof onCloseRequest === 'function') {
+                            onCloseRequest({
+                                type: 'enable',
+                                reactEvent: event,
+                                nativeEvent: event.nativeEvent
+                            });
+                        }
+                    }
+                }
+            }
+            :
+            null;
+        return [cancelButton, configureButton, toggleButton, disableButton, enableButton].filter(Boolean);
     }, [addonDetails, onCloseRequest]);
     const modalBackground = React.useMemo(() => {
         return addonDetails.remoteAddon?.content.type === 'Ready' ? addonDetails.remoteAddon.content.content.manifest.background : null;

--- a/src/routes/Addons/Addon/Addon.js
+++ b/src/routes/Addons/Addon/Addon.js
@@ -1,5 +1,3 @@
-// Copyright (C) 2017-2023 Smart code 203358507
-
 const React = require('react');
 const PropTypes = require('prop-types');
 const classnames = require('classnames');
@@ -8,7 +6,7 @@ const { default: Icon } = require('@stremio/stremio-icons/react');
 const { Button, Image } = require('stremio/common');
 const styles = require('./styles');
 
-const Addon = ({ className, id, name, version, logo, description, types, behaviorHints, installed, onToggle, onConfigure, onShare, dataset }) => {
+const Addon = ({ className, id, name, version, logo, description, types, behaviorHints, installed, disabled, onToggle, onConfigure, onShare, dataset }) => {
     const { t } = useTranslation();
     const toggleButtonOnClick = React.useCallback((event) => {
         if (typeof onToggle === 'function') {
@@ -111,6 +109,22 @@ const Addon = ({ className, id, name, version, logo, description, types, behavio
                     >
                         <div className={styles['label']}>{installed ? t('ADDON_UNINSTALL') : behaviorHints.configurationRequired ? t('ADDON_CONFIGURE') : t('ADDON_INSTALL')}</div>
                     </Button>
+                    {
+                        installed && !disabled ?
+                            <Button className={styles['disable-button-container']} title={t('ADDON_DISABLE')} tabIndex={-1} onClick={toggleButtonOnClick}>
+                                <div className={styles['label']}>{t('ADDON_DISABLE')}</div>
+                            </Button>
+                            :
+                            null
+                    }
+                    {
+                        installed && disabled ?
+                            <Button className={styles['enable-button-container']} title={t('ADDON_ENABLE')} tabIndex={-1} onClick={toggleButtonOnClick}>
+                                <div className={styles['label']}>{t('ADDON_ENABLE')}</div>
+                            </Button>
+                            :
+                            null
+                    }
                 </div>
                 <Button className={styles['share-button-container']} title={t('SHARE_ADDON')} tabIndex={-1} onClick={shareButtonOnClick}>
                     <Icon className={styles['icon']} name={'share'} />
@@ -136,6 +150,7 @@ Addon.propTypes = {
         p2p: PropTypes.bool,
     }),
     installed: PropTypes.bool,
+    disabled: PropTypes.bool,
     onToggle: PropTypes.func,
     onConfigure: PropTypes.func,
     onShare: PropTypes.func,

--- a/src/services/Core/Core.js
+++ b/src/services/Core/Core.js
@@ -1,5 +1,3 @@
-// Copyright (C) 2017-2023 Smart code 203358507
-
 const EventEmitter = require('eventemitter3');
 const CoreTransport = require('./CoreTransport');
 
@@ -86,6 +84,30 @@ function Core(args) {
     };
     this.off = function(name, listener) {
         events.off(name, listener);
+    };
+
+    this.disableAddon = function(addon) {
+        if (transport !== null) {
+            transport.dispatch({
+                action: 'Ctx',
+                args: {
+                    action: 'DisableAddon',
+                    args: addon
+                }
+            });
+        }
+    };
+
+    this.enableAddon = function(addon) {
+        if (transport !== null) {
+            transport.dispatch({
+                action: 'Ctx',
+                args: {
+                    action: 'EnableAddon',
+                    args: addon
+                }
+            });
+        }
     };
 }
 


### PR DESCRIPTION
Fixes Stremio/stremio-features#1254

Add functionality to disable and enable add-ons without uninstalling them.

* **`src/common/AddonDetailsModal/AddonDetailsModal.js`**
  - Add "Disable" button for installed add-ons.
  - Add "Enable" button for disabled add-ons.
  - Modify `modalButtons` to include the new buttons.

* **`src/routes/Addons/Addon/Addon.js`**
  - Add "Disable" button for installed add-ons.
  - Add "Enable" button for disabled add-ons.
  - Modify `toggleButtonOnClick` function to handle disabling and enabling add-ons.
  - Update PropTypes to include `disabled`.

* **`src/services/Core/Core.js`**
  - Add method to disable an add-on.
  - Add method to enable an add-on.

