### PR TITLE
fix: bug when clicking on mark as watched button

### DIFF
--- a/src/routes/MetaDetails/VideosList/Video/Video.js
+++ b/src/routes/MetaDetails/VideosList/Video/Video.js
@@ -47,6 +47,7 @@ const Video = ({ className, id, title, thumbnail, episode, released, upcoming, w
     }, []);
     const toggleWatchedOnClick = React.useCallback((event) => {
         event.preventDefault();
+        event.stopPropagation();
         closeMenu();
         core.transport.dispatch({
             action: 'MetaDetails',


### PR DESCRIPTION
When you clicked mark as watched inside the video component menu you were automatically redirected to the streams page because of event propagation