### PR TITLE
Fix: styles on metaDetails / Streams page

### DIFF
--- a/src/common/Multiselect/styles.less
+++ b/src/common/Multiselect/styles.less
@@ -27,6 +27,9 @@
         max-height: 2.4em;
         font-weight: 500;
         color: var(--primary-foreground-color);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .icon {

--- a/src/routes/MetaDetails/StreamsList/Stream/styles.less
+++ b/src/routes/MetaDetails/StreamsList/Stream/styles.less
@@ -58,7 +58,7 @@
 
         .addon-name {
             width: 7rem;
-            max-height: 3.6em;
+            max-height:4em;
             font-size: 1.1rem;
             text-align: left;
             color: var(--primary-foreground-color);

--- a/src/routes/MetaDetails/StreamsList/Stream/styles.less
+++ b/src/routes/MetaDetails/StreamsList/Stream/styles.less
@@ -58,7 +58,6 @@
 
         .addon-name {
             width: 7rem;
-            max-height:4em;
             font-size: 1.1rem;
             text-align: left;
             color: var(--primary-foreground-color);

--- a/src/routes/MetaDetails/StreamsList/styles.less
+++ b/src/routes/MetaDetails/StreamsList/styles.less
@@ -108,7 +108,6 @@
 
         .select-input-container {
             min-width: 40%;
-            flex: 0 0 auto;
             flex-grow: 1;
             background: none;
 


### PR DESCRIPTION
## Fixes:

- The addon label was cut if the addon name was too long on the `Stream` component 
- Long addon names were casuing overflow on the `multiSelect` component

### Tested on: 
- [x]  iPad PWA
