### PR TITLE
fix: nav-menu height

### DIFF
--- a/src/common/NavBar/HorizontalNavBar/NavMenu/styles.less
+++ b/src/common/NavBar/HorizontalNavBar/NavMenu/styles.less
@@ -14,7 +14,7 @@
 }
 .nav-menu-container {
     width: 22rem;
-    max-height: calc(100vh - var(--horizontal-nav-bar-size));
+    max-height: calc(100vh - var(--horizontal-nav-bar-size) - 1rem);
     overflow-y: auto;
     border-radius: var(--border-radius);
     background-color: var(--modal-background-color);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b0c49766-dd1a-4b42-a0e1-e88326c05a12)

- added some empty space so the menu ends before the end of the page

### Before
![image](https://github.com/user-attachments/assets/208a6cfa-eda8-4a1a-9ac4-adbd770c9179)

