### PR TITLE
fix: multiselectMenu and Multiselect height

### DIFF
--- a/src/common/ModalDialog/styles.less
+++ b/src/common/ModalDialog/styles.less
@@ -82,7 +82,7 @@
             .body-container {
                 flex: 1;
                 align-self: stretch;
-                overflow-y: auto;
+                overflow: visible;
                 padding: 2rem 0;
 
                 &:last-child {

--- a/src/common/Multiselect/styles.less
+++ b/src/common/Multiselect/styles.less
@@ -7,6 +7,8 @@
     popup-menu-container: menu-container;
 }
 
+@parent-height: 6rem;
+
 .label-container {
     display: flex;
     flex-direction: row;
@@ -48,6 +50,8 @@
 
 .modal-container, .popup-menu-container {
     .menu-container {
+        max-height: calc(100dvh - var(--horizontal-nav-bar-size) - @parent-height);
+
         .option-container {
             display: flex;
             flex-direction: row;

--- a/src/common/Multiselect/styles.less
+++ b/src/common/Multiselect/styles.less
@@ -7,7 +7,7 @@
     popup-menu-container: menu-container;
 }
 
-@parent-height: 6rem;
+@parent-height: 10rem;
 
 .label-container {
     display: flex;
@@ -50,7 +50,7 @@
 
 .modal-container, .popup-menu-container {
     .menu-container {
-        max-height: calc(100dvh - var(--horizontal-nav-bar-size) - @parent-height);
+        max-height: calc(3.2rem * 7);
 
         .option-container {
             display: flex;
@@ -103,6 +103,14 @@
                 text-align: center;
                 color: @color-surface-light5-90;
             }
+        }
+    }
+}
+
+@media (orientation: landscape) and (max-width: @xsmall) {
+    .modal-container, .popup-menu-container {
+        .menu-container {
+            max-height: calc(100dvh - var(--horizontal-nav-bar-size) - @parent-height);
         }
     }
 }

--- a/src/common/MultiselectMenu/Dropdown/Dropdown.less
+++ b/src/common/MultiselectMenu/Dropdown/Dropdown.less
@@ -2,7 +2,7 @@
 
 @import (reference) '~stremio/common/screen-sizes.less';
 
-@parent-height: 6rem;
+@parent-height: 10rem;
 
 .dropdown {
     background: var(--modal-background-color);
@@ -18,7 +18,7 @@
 
     &.open {
         display: block;
-        max-height: calc(100dvh - var(--horizontal-nav-bar-size) - @parent-height);
+        max-height: calc(3.3rem * 7);
         overflow: auto;
     }
 
@@ -31,6 +31,14 @@
 
         .back-button-icon {
             width: 1.5rem;
+        }
+    }
+}
+
+@media (orientation: landscape) and (max-width: @xsmall) {
+    .dropdown {
+        &.open {
+            max-height: calc(100dvh - var(--horizontal-nav-bar-size) - @parent-height);
         }
     }
 }

--- a/src/common/MultiselectMenu/Dropdown/Dropdown.less
+++ b/src/common/MultiselectMenu/Dropdown/Dropdown.less
@@ -2,6 +2,8 @@
 
 @import (reference) '~stremio/common/screen-sizes.less';
 
+@parent-height: 6rem;
+
 .dropdown {
     background: var(--modal-background-color);
     display: none;
@@ -16,7 +18,7 @@
 
     &.open {
         display: block;
-        max-height: calc(3.2rem * 10);
+        max-height: calc(100dvh - var(--horizontal-nav-bar-size) - @parent-height);
         overflow: auto;
     }
 
@@ -29,14 +31,6 @@
 
         .back-button-icon {
             width: 1.5rem;
-        }
-    }
-}
-
-@media only screen and (max-width: @minimum) {
-    .dropdown {
-        &.open {
-            max-height: calc(3.2rem * 7);
         }
     }
 }

--- a/src/routes/Addons/styles.less
+++ b/src/routes/Addons/styles.less
@@ -155,6 +155,10 @@
             .select-input-container {
                 height: 3rem;
 
+                .multiselect-menu-container {
+                    overflow: auto;
+                }
+
                 &:not(:last-child) {
                     margin-bottom: 1rem;
                 }

--- a/src/routes/Addons/styles.less
+++ b/src/routes/Addons/styles.less
@@ -89,7 +89,6 @@
                 margin-right: 1.5rem;
 
                 .multiselect-menu-container {
-                    max-height: calc(3.2rem * 7);
                     overflow: auto;
                 }
             }

--- a/src/routes/Discover/styles.less
+++ b/src/routes/Discover/styles.less
@@ -57,7 +57,6 @@
                     }
 
                     .multiselect-menu-container {
-                        max-height: calc(3.2rem * 7);
                         overflow: auto;
                     }
                 }
@@ -220,7 +219,7 @@
                 }
 
                 .multiselect-menu-container {
-                    max-height: calc(3.2rem * 4);
+                    max-height: calc(3.2rem * 3);
                     overflow: auto;
                 }
             }

--- a/src/routes/Library/styles.less
+++ b/src/routes/Library/styles.less
@@ -42,7 +42,6 @@
                 }
 
                 .multiselect-menu-container {
-                    max-height: calc(3.2rem * 7);
                     overflow: auto;
                 }
             }

--- a/src/routes/MetaDetails/StreamsList/styles.less
+++ b/src/routes/MetaDetails/StreamsList/styles.less
@@ -124,7 +124,6 @@
             }
     
             .multiselect-menu-container {
-                max-height: calc(3.2rem * 7);
                 overflow: auto;
             }
         }

--- a/src/routes/MetaDetails/VideosList/SeasonsBar/styles.less
+++ b/src/routes/MetaDetails/VideosList/SeasonsBar/styles.less
@@ -77,7 +77,6 @@
         }
 
         .multiselect-menu-container {
-            max-height: calc(3.2rem * 7);
             overflow: auto;
         }
     }
@@ -86,11 +85,5 @@
 @media only screen and (max-width: @minimum) {
     .seasons-bar-container {
         height: 6rem;
-
-        .seasons-popup-label-container {
-            .multiselect-menu-container {
-                max-height: calc(3.2rem * 3);
-            }
-        }
     }
 }


### PR DESCRIPTION
- The height of the `Multiselect` and `MultiselectMenu` was not calculated properly.
- After fixing the problem with the pop-up overflow some time ago a new problem is getting fixed here with dropdowns inside pop-ups on being visible (another time overflow issue) i propose we move away from popups completely in the future

-  Changes  introduced: 
 1. We set the height only globally for the component and try not to set it locally for each case.
 2. We use `@media (orientation: landscape) and (max-width: @xsmall)` to set the size for smaller landscape devices (there are no devices that are vertical and are smaller than `calc(3.2rem * 7)`)
 4. Overflow issue on popups having dropdowns resolved. 

- Future notes: 
 1. Move completely to using `MultiselectMenu` component instead of the old `MultiSelect`
### Now
![image](https://github.com/user-attachments/assets/c8b3699e-59fa-4130-8f43-0f98ee6196a0)
![image](https://github.com/user-attachments/assets/07f9d641-01af-4e73-9819-7a6313d96ef2)
![image](https://github.com/user-attachments/assets/cc22ffe3-1354-462c-94f1-98e4569b8b05)


### Before
![image](https://github.com/user-attachments/assets/11618233-c2ba-4e96-b6df-57739e5e273f)
![image](https://github.com/user-attachments/assets/638c116f-fb82-4ffe-840c-b37db8246136)
