### PR TITLE
fix: colorInput component styles

### DIFF
--- a/src/common/ColorInput/styles.less
+++ b/src/common/ColorInput/styles.less
@@ -17,7 +17,6 @@
         align-items: center;
         justify-content: center;
         padding: 0 0.5rem;
-        border: thin solid @color-surface-light5-20;
         pointer-events: none;
 
         .transparent-label {

--- a/src/routes/Settings/styles.less
+++ b/src/routes/Settings/styles.less
@@ -316,7 +316,14 @@
                         }
 
                         &.color-input-container {
-                            padding: 1.75rem 1rem;
+                            padding: 1.3rem 1rem;
+                            border-radius: 3rem;
+                            border: 2px solid transparent;
+                            transition: 0.3s all ease-in-out;
+
+                            &:hover {
+                                border-color: var(--overlay-color);
+                            }
                         }
 
                         &.info-container {


### PR DESCRIPTION
- there was a case where because of lack of border-radius on `ColorInput` component when you opened the subtitles langauge dropdown you thought it does not have border-radius on the bottom.
- changed the padding to align with the dropdowns size