### PR TITLE
fix: use the default height set in the component

### DIFF
--- a/src/routes/Settings/styles.less
+++ b/src/routes/Settings/styles.less
@@ -286,7 +286,6 @@
                             }
 
                             .multiselect-menu-container {
-                                max-height: calc(3.2rem * 7);
                                 overflow: auto;
                             }
                         }


### PR DESCRIPTION
- using the default height for the `Multiselect` component in the settings now