### PR TITLE
Background fix and Binge Watch fix for stremio-shell with stremio-web v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /npm-debug.log
 .DS_Store
 .prettierignore
+/.idea/

--- a/src/common/NavBar/HorizontalNavBar/HorizontalNavBar.js
+++ b/src/common/NavBar/HorizontalNavBar/HorizontalNavBar.js
@@ -15,8 +15,6 @@ const { t } = require('i18next');
 
 const HorizontalNavBar = React.memo(({ className, route, query, title, backButton, searchBar, fullscreenButton, navMenu, ...props }) => {
     const backButtonOnClick = React.useCallback(() => {
-        if (document.querySelector('body').style.background) document.querySelector('body').style.background = '';
-        if (document.getElementById('app').style.background) document.getElementById('app').style.background = '';
         window.history.back();
     }, []);
     const [fullscreen, requestFullscreen, exitFullscreen] = useFullscreen();

--- a/src/common/NavBar/HorizontalNavBar/HorizontalNavBar.js
+++ b/src/common/NavBar/HorizontalNavBar/HorizontalNavBar.js
@@ -15,6 +15,8 @@ const { t } = require('i18next');
 
 const HorizontalNavBar = React.memo(({ className, route, query, title, backButton, searchBar, fullscreenButton, navMenu, ...props }) => {
     const backButtonOnClick = React.useCallback(() => {
+        document.querySelector('body').style.background = '';
+        document.getElementById('app').style.background = '';
         window.history.back();
     }, []);
     const [fullscreen, requestFullscreen, exitFullscreen] = useFullscreen();

--- a/src/common/NavBar/HorizontalNavBar/HorizontalNavBar.js
+++ b/src/common/NavBar/HorizontalNavBar/HorizontalNavBar.js
@@ -15,8 +15,8 @@ const { t } = require('i18next');
 
 const HorizontalNavBar = React.memo(({ className, route, query, title, backButton, searchBar, fullscreenButton, navMenu, ...props }) => {
     const backButtonOnClick = React.useCallback(() => {
-        document.querySelector('body').style.background = '';
-        document.getElementById('app').style.background = '';
+        if (document.querySelector('body').style.background) document.querySelector('body').style.background = '';
+        if (document.getElementById('app').style.background) document.getElementById('app').style.background = '';
         window.history.back();
     }, []);
     const [fullscreen, requestFullscreen, exitFullscreen] = useFullscreen();

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -78,6 +78,8 @@ const Player = ({ urlParams, queryParams }) => {
     }, [immersed, casting, video.state.paused, menusOpen, nextVideoPopupOpen]);
 
     const nextVideoPopupDismissed = React.useRef(false);
+    const nextVideoInitialData = React.useRef(player.nextVideo);
+    nextVideoInitialData.current = player.nextVideo;
     const defaultSubtitlesSelected = React.useRef(false);
     const defaultAudioTrackSelected = React.useRef(false);
     const [error, setError] = React.useState(null);
@@ -95,11 +97,8 @@ const Player = ({ urlParams, queryParams }) => {
         video.setProp('extraSubtitlesOutlineColor', settings.subtitlesOutlineColor);
     }, [settings.subtitlesSize, settings.subtitlesOffset, settings.subtitlesTextColor, settings.subtitlesBackgroundColor, settings.subtitlesOutlineColor]);
 
-    const stableNextVideoRef = React.useRef(player.nextVideo);
-    stableNextVideoRef.current = player.nextVideo;
-
     const onEnded = React.useCallback(() => {
-        player.nextVideo = stableNextVideoRef.current;
+        player.nextVideo = nextVideoInitialData.current;
         ended();
         if (player.nextVideo !== null) {
             onNextVideoRequested();
@@ -211,10 +210,7 @@ const Player = ({ urlParams, queryParams }) => {
             const deepLinks = player.nextVideo.deepLinks;
             if (deepLinks.metaDetailsStreams && deepLinks.player) {
                 window.location.replace(deepLinks.metaDetailsStreams);
-                setTimeout(function() {
-                    //Qt5 fix. Has to be >600 otherwise qt: [ffmpeg] tls: Unknown error
-                    window.location.href = deepLinks.player;
-                }, 600);
+                window.location.href = deepLinks.player;
             } else {
                 window.location.replace(deepLinks.player ?? deepLinks.metaDetailsStreams);
             }

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -466,6 +466,7 @@ const Player = ({ urlParams, queryParams }) => {
     React.useLayoutEffect(() => {
         const onKeyDown = (event) => {
             switch (event.code) {
+                case 'MediaPlayPause':
                 case 'Space': {
                     if (!menusOpen && !nextVideoPopupOpen && video.state.paused !== null) {
                         if (video.state.paused) {
@@ -479,6 +480,7 @@ const Player = ({ urlParams, queryParams }) => {
                     break;
                 }
                 case 'Numpad6':
+                case 'MediaTrackNext':
                 case 'ArrowRight': {
                     if (!menusOpen && !nextVideoPopupOpen && video.state.time !== null) {
                         const seekDuration = event.shiftKey ? settings.seekShortTimeDuration : settings.seekTimeDuration;
@@ -489,6 +491,7 @@ const Player = ({ urlParams, queryParams }) => {
                     break;
                 }
                 case 'Numpad4':
+                case 'MediaTrackPrevious':
                 case 'ArrowLeft': {
                     if (!menusOpen && !nextVideoPopupOpen && video.state.time !== null) {
                         const seekDuration = event.shiftKey ? settings.seekShortTimeDuration : settings.seekTimeDuration;

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -478,6 +478,7 @@ const Player = ({ urlParams, queryParams }) => {
 
                     break;
                 }
+                case 'Numpad6':
                 case 'ArrowRight': {
                     if (!menusOpen && !nextVideoPopupOpen && video.state.time !== null) {
                         const seekDuration = event.shiftKey ? settings.seekShortTimeDuration : settings.seekTimeDuration;
@@ -487,6 +488,7 @@ const Player = ({ urlParams, queryParams }) => {
 
                     break;
                 }
+                case 'Numpad4':
                 case 'ArrowLeft': {
                     if (!menusOpen && !nextVideoPopupOpen && video.state.time !== null) {
                         const seekDuration = event.shiftKey ? settings.seekShortTimeDuration : settings.seekTimeDuration;
@@ -496,6 +498,7 @@ const Player = ({ urlParams, queryParams }) => {
 
                     break;
                 }
+                case 'Numpad8':
                 case 'ArrowUp': {
                     if (!menusOpen && !nextVideoPopupOpen && video.state.volume !== null) {
                         onVolumeChangeRequested(video.state.volume + 5);
@@ -503,6 +506,7 @@ const Player = ({ urlParams, queryParams }) => {
 
                     break;
                 }
+                case 'Numpad2':
                 case 'ArrowDown': {
                     if (!menusOpen && !nextVideoPopupOpen && video.state.volume !== null) {
                         onVolumeChangeRequested(video.state.volume - 5);
@@ -559,7 +563,7 @@ const Player = ({ urlParams, queryParams }) => {
             }
         };
         const onKeyUp = (event) => {
-            if (event.code === 'ArrowRight' || event.code === 'ArrowLeft') {
+            if (event.code === 'ArrowRight' || event.code === 'ArrowLeft' || event.code === 'Numpad6' || event.code === 'Numpad4') {
                 setSeeking(false);
             }
         };

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -207,7 +207,10 @@ const Player = ({ urlParams, queryParams }) => {
             const deepLinks = player.nextVideo.deepLinks;
             if (deepLinks.metaDetailsStreams && deepLinks.player) {
                 window.location.replace(deepLinks.metaDetailsStreams);
-                window.location.href = deepLinks.player;
+                setTimeout(function() {
+                    //Qt5 fix. Has to be >600 otherwise qt: [ffmpeg] tls: Unknown error
+                    window.location.href = deepLinks.player;
+                }, 600);
             } else {
                 window.location.replace(deepLinks.player ?? deepLinks.metaDetailsStreams);
             }

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -95,7 +95,11 @@ const Player = ({ urlParams, queryParams }) => {
         video.setProp('extraSubtitlesOutlineColor', settings.subtitlesOutlineColor);
     }, [settings.subtitlesSize, settings.subtitlesOffset, settings.subtitlesTextColor, settings.subtitlesBackgroundColor, settings.subtitlesOutlineColor]);
 
+    const stableNextVideoRef = React.useRef(player.nextVideo);
+    stableNextVideoRef.current = player.nextVideo;
+
     const onEnded = React.useCallback(() => {
+        player.nextVideo = stableNextVideoRef.current;
         ended();
         if (player.nextVideo !== null) {
             onNextVideoRequested();
@@ -603,6 +607,8 @@ const Player = ({ urlParams, queryParams }) => {
             video.events.off('subtitlesTrackLoaded', onSubtitlesTrackLoaded);
             video.events.off('extraSubtitlesTrackLoaded', onExtraSubtitlesTrackLoaded);
             video.events.off('implementationChanged', onImplementationChanged);
+            if (document.querySelector('body').style.background) document.querySelector('body').style.background = '';
+            if (document.getElementById('app').style.background) document.getElementById('app').style.background = '';
         };
     }, []);
 


### PR DESCRIPTION
### ⚠️ What Issues
1. Transparent background not reset using back button when watching via stremio-shell
2. Binge watching next video not working at all via stremio-shell qt5

### ✨ How Fixed
1. Fixed by resetting background on click of the back button
2. Seems like a timeout of >600ms fixes this as the fast redirect causes a _fake_ tls error. This seems to be a compatibility issue with qt5 and the old chromium version that it uses. On the stremio-shell side the only error is `[ffmpeg] tls: Unknown error` which does not really help. Tried also on window load and dom content load but both did not work.

### ℹ Qt5 issues moving to Qt6

- In general the web v5 ui and qt5 do not really work well together. Using [stremio-shell](https://github.com/Stremio/stremio-shell) build with qt5.12.2 the ui is fully unresponsive and non functional. Seems like this [issue](https://github.com/Stremio/stremio-shell/issues/395) is also related.
- This got fixed using the latest qt5: `5.15.16` built with vcpkg. ~Can be tested here: [stremio-shell-web-v5](https://github.com/Zaarrg/stremio-shell-web-v5) .~
- Qt6 [here](https://github.com/Zaarrg/stremio-desktop-v5), wayyy better then qt5.
- I suspect it's the old chromium version combined with the react web ui. As qt5.15.16 has a more recent chromium version and that fixed many issues.
- But even with this there are still some issue, like the pop in fade animation on the show banners when u visit a new page being quite slow / lagging.
- All those qt issues got fixed when I built stremio-shell using latest qt6  [here](https://github.com/Zaarrg/stremio-desktop-v5). ~Sadly qt6 cant be used atm as it does not allow the webview background to be transparent and render the video behind it. See this offical [bug-tracker](https://bugreports.qt.io/browse/QTBUG-111739). When this bug is fixed qt6 can be used.~

