### PR TITLE
fix: toats outer glow problem with overflow

### DIFF
--- a/src/App/styles.less
+++ b/src/App/styles.less
@@ -38,7 +38,7 @@
     --quaternary-accent-color: rgba(18, 69, 166, 1);
     --overlay-color: rgba(255, 255, 255, 0.05);
     --modal-background-color: rgba(15, 13, 32, 1);
-    --outer-glow: 0px 0px 30px rgba(123, 91, 245, 0.37);
+    --outer-glow: 0px 0px 15px rgba(123, 91, 245, 0.37);
     --border-radius: 0.75rem;
 }
 
@@ -112,7 +112,7 @@ html {
                 left: auto;
                 z-index: 1;
                 padding: 0 calc(0.5 * var(--horizontal-nav-bar-size));
-                overflow-y: auto;
+                overflow: visible;
                 scrollbar-width: none;
                 pointer-events: none;
 


### PR DESCRIPTION
- the toasts container was making the outer glow not show on the top side of the first notification toast