### PR TITLE
Fix Poster Sharpness

### DIFF
--- a/src/common/MetaItem/styles.less
+++ b/src/common/MetaItem/styles.less
@@ -166,6 +166,7 @@
                 object-position: center;
                 object-fit: cover;
                 opacity: 0.9;
+                overflow-clip-margin: unset;
             }
 
             .placeholder-icon {


### PR DESCRIPTION
Chrome (on Windows only) was showing the posters with high sharpness, this made it hard to read text on some posters (including the title), this one css style seems to fix that and I didn't notice it impacting other cases yet.