### PR TITLE
Refactor/calendar styles

### DIFF
--- a/src/routes/Calendar/Calendar.less
+++ b/src/routes/Calendar/Calendar.less
@@ -14,7 +14,7 @@
         gap: 0.5rem;
         width: 100%;
         height: 100%;
-        padding: 0 0 2rem 2rem;
+        padding: 0 0 calc(1.5rem + var(--safe-area-inset-bottom)) 2rem;
 
         .main {
             flex: auto;
@@ -37,7 +37,7 @@
 @media only screen and (max-width: @small) and (orientation: landscape) {
     .calendar {
         .content {
-            padding: 0 0 0 1rem;
+            padding: 0 0 calc(1.5rem + var(--safe-area-inset-bottom)) 1rem;
         }
     }
 }

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -164,3 +164,13 @@
         }
     }
 }
+
+@media only screen and (max-height: @xsmall) and (max-width: @xsmall) {
+    .cell {
+        .items {
+            .item {
+                pointer-events: none;
+            }
+        }
+    }
+}

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -168,6 +168,8 @@
 @media only screen and (max-height: @xsmall) and (max-width: @xsmall) {
     .cell {
         .items {
+            padding: 0.25rem;
+
             .item {
                 pointer-events: none;
             }

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -55,7 +55,7 @@
         display: flex;
         flex-direction: row;
         gap: 1rem;
-        padding: 0 1rem 1rem 1rem;
+        padding: 0 0.5rem 0.5rem 0.5rem;
 
         .item {
             flex: none;
@@ -134,7 +134,7 @@
     }
 }
 
-@media only screen and (max-height: @xxsmall) and (orientation: portrait) {
+@media only screen and (max-height: @minimum) and (orientation: portrait) {
     .cell {
         .heading {
             justify-content: center;
@@ -167,11 +167,22 @@
 
 @media only screen and (max-height: @xsmall) and (max-width: @xsmall) {
     .cell {
+        gap: 0;
+
+        .heading {
+            height: 2rem;
+
+            .day {
+                font-size: 0.875rem;
+            }
+        }
+
         .items {
             padding: 0.25rem;
 
             .item {
                 pointer-events: none;
+                border-radius: calc(var(--border-radius) / 2);
             }
         }
     }

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -134,7 +134,7 @@
     }
 }
 
-@media only screen and (orientation: portrait) {
+@media only screen and (max-height: @xxsmall) and (orientation: portrait) {
     .cell {
         .heading {
             justify-content: center;
@@ -150,23 +150,11 @@
     }
 }
 
-@media only screen and (max-width: @small) and (orientation: landscape) {
+@media only screen and (max-height: @xxsmall) and (orientation: landscape) {
     .cell {
         flex-direction: row;
         align-items: center;
 
-        .items {
-           display: none;
-        }
-
-        .more {
-            display: flex;
-        }
-    }
-}
-
-@media only screen and (max-height: @xxsmall) and (orientation: landscape) {
-    .cell {
         .items {
             display: none;
         }

--- a/src/routes/Calendar/Table/Cell/Cell.tsx
+++ b/src/routes/Calendar/Table/Cell/Cell.tsx
@@ -1,6 +1,6 @@
 // Copyright (C) 2017-2024 Smart code 203358507
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, MouseEvent } from 'react';
 import Icon from '@stremio/stremio-icons/react';
 import classNames from 'classnames';
 import { Button, HorizontalScroll, Image } from 'stremio/components';
@@ -24,6 +24,10 @@ const Cell = ({ selected, monthInfo, date, items, onClick }: Props) => {
         onClick && onClick(date);
     };
 
+    const onPosterClick = useCallback((event: MouseEvent<HTMLDivElement>) => {
+        event.stopPropagation();
+    }, []);
+
     return (
         <Button
             className={classNames(styles['cell'], { [styles['active']]: active, [styles['today']]: today })}
@@ -37,7 +41,7 @@ const Cell = ({ selected, monthInfo, date, items, onClick }: Props) => {
             <HorizontalScroll className={styles['items']}>
                 {
                     items.map(({ id, name, poster, deepLinks }) => (
-                        <Button key={id} className={styles['item']} href={deepLinks.metaDetailsStreams} tabIndex={-1}>
+                        <Button key={id} className={styles['item']} href={deepLinks.metaDetailsStreams} tabIndex={-1} onClick={onPosterClick}>
                             <Icon className={styles['icon']} name={'play'} />
                             <Image
                                 className={styles['poster']}


### PR DESCRIPTION
- Makes the posters visible on smaller screen sizes
- Adds `stopPropagation` to the Poster to not open the `BottomSheet` when clicked on the poster

### Small size desktop / laptop
<img height="200" alt="Screenshot 2025-01-06 at 20 51 41" src="https://github.com/user-attachments/assets/a558a81c-4c4d-41a6-aa9e-eda90fbc0f33" />

### Portrait iPad
<img height="150" alt="Screenshot 2025-01-06 at 20 51 41" src="https://github.com/user-attachments/assets/65fb7693-0ec4-4dfd-9526-8810ea384447" />

### Portrait iPhone
<img height="150" alt="Screenshot 2025-01-06 at 20 51 41" src="https://github.com/user-attachments/assets/bffc962d-bac8-4eef-b4f5-86a3b440418b" />

## For testers

https://stremio.github.io/stremio-web/refactor/calendar-styles
