### PR TITLE
Search: Hide empty catalog rows

### DIFF
--- a/src/routes/Search/Search.js
+++ b/src/routes/Search/Search.js
@@ -97,14 +97,17 @@ const Search = ({ queryParams }) => {
                                         );
                                     }
                                     case 'Err': {
-                                        return (
-                                            <MetaRow
-                                                key={index}
-                                                className={classnames(styles['search-row'], 'animation-fade-in')}
-                                                catalog={catalog}
-                                                message={catalog.content.content}
-                                            />
-                                        );
+                                        if (catalog.content.content !== 'EmptyContent') {
+                                            return (
+                                                <MetaRow
+                                                    key={index}
+                                                    className={classnames(styles['search-row'], 'animation-fade-in')}
+                                                    catalog={catalog}
+                                                    message={catalog.content.content}
+                                                />
+                                            );
+                                        }
+                                        return null;
                                     }
                                     default: {
                                         return (


### PR DESCRIPTION
- the addon err response with empty content were not hidden on search