### PR TITLE
MetaDetails: Add stream title and icons on context menu

### DIFF
--- a/src/routes/MetaDetails/StreamsList/Stream/Stream.js
+++ b/src/routes/MetaDetails/StreamsList/Stream/Stream.js
@@ -181,12 +181,17 @@ const Stream = ({ className, videoId, videoReleased, addonName, name, descriptio
     const renderMenu = React.useMemo(() => function renderMenu() {
         return (
             <div className={styles['context-menu-content']} onPointerDown={popupMenuOnPointerDown} onContextMenu={popupMenuOnContextMenu} onClick={popupMenuOnClick} onKeyDown={popupMenuOnKeyDown}>
+                <div className={styles['context-menu-title']}>
+                    {description}
+                </div>
                 <Button className={styles['context-menu-option-container']} title={t('CTX_PLAY')}>
+                    <Icon className={styles['menu-icon']} name={'play'} />
                     <div className={styles['context-menu-option-label']}>{t('CTX_PLAY')}</div>
                 </Button>
                 {
                     streamLink &&
                         <Button className={styles['context-menu-option-container']} title={t('CTX_COPY_STREAM_LINK')} onClick={copyStreamLink}>
+                            <Icon className={styles['menu-icon']} name={'link'} />
                             <div className={styles['context-menu-option-label']}>{t('CTX_COPY_STREAM_LINK')}</div>
                         </Button>
                 }

--- a/src/routes/MetaDetails/StreamsList/Stream/styles.less
+++ b/src/routes/MetaDetails/StreamsList/Stream/styles.less
@@ -111,12 +111,29 @@
         background-color: var(--secondary-accent-color);
     }
 
+    .menu-icon {
+        flex: none;
+        width: 1.7rem;
+        height: 1.7rem;
+        margin-right: 1rem;
+        color: var(--color-placeholder);
+    }
+
 	.context-menu-container {
 		max-width: calc(90% - 1.5rem);
 		z-index: 2;
 	
 		.context-menu-content {
 			--spatial-navigation-contain: contain;
+
+            .context-menu-title {
+                font-size: 0.9rem;
+                padding: 1rem 1.5rem;
+                font-weight: 100;
+                border-bottom: 1px solid var(--color-placeholder);
+                color: var(--primary-foreground-color);
+                white-space: break-spaces;
+            }
 	
 			.context-menu-option-container {
 				display: flex;
@@ -131,8 +148,9 @@
 	
 				.context-menu-option-label {
 					font-size: 1rem;
-					font-weight: 500;
-					color:var(--primary-foreground-color);
+					font-weight: 300;
+					color: var(--primary-foreground-color);
+                    text-transform: capitalize;
 				}
 			}
 		}


### PR DESCRIPTION
**Changes:**
  - Added a right click preview for stream names on desktop.
  - Implemented a touch preview for mobile users.
  - Adjusted styling to ensure better visibility of stream names.
  - Buttons **play** and **Copy Stream Link** remains in the menu
  
  Closes [Issue #375](https://github.com/Stremio/stremio-tasks/issues/375#issuecomment-2633575890)