### PR TITLE
Player: Reduce volume slider when muted

### DIFF
--- a/src/routes/Player/ControlBar/ControlBar.js
+++ b/src/routes/Player/ControlBar/ControlBar.js
@@ -138,6 +138,7 @@ const ControlBar = ({
                 <VolumeSlider
                     className={styles['volume-slider']}
                     volume={volume}
+                    muted={muted}
                     onVolumeChangeRequested={onVolumeChangeRequested}
                 />
                 <div className={styles['spacing']} />

--- a/src/routes/Player/ControlBar/VolumeSlider/VolumeSlider.js
+++ b/src/routes/Player/ControlBar/VolumeSlider/VolumeSlider.js
@@ -8,7 +8,7 @@ const { useRouteFocused } = require('stremio-router');
 const { Slider } = require('stremio/components');
 const styles = require('./styles');
 
-const VolumeSlider = ({ className, volume, onVolumeChangeRequested }) => {
+const VolumeSlider = ({ className, volume, onVolumeChangeRequested, muted }) => {
     const disabled = volume === null || isNaN(volume);
     const routeFocused = useRouteFocused();
     const [slidingVolume, setSlidingVolume] = React.useState(null);
@@ -45,7 +45,9 @@ const VolumeSlider = ({ className, volume, onVolumeChangeRequested }) => {
             className={classnames(className, styles['volume-slider'], { 'active': slidingVolume !== null })}
             value={
                 !disabled ?
-                    slidingVolume !== null ? slidingVolume : volume
+                    !muted ?
+                        slidingVolume !== null ? slidingVolume : volume
+                        : 0
                     :
                     100
             }
@@ -61,7 +63,8 @@ const VolumeSlider = ({ className, volume, onVolumeChangeRequested }) => {
 VolumeSlider.propTypes = {
     className: PropTypes.string,
     volume: PropTypes.number,
-    onVolumeChangeRequested: PropTypes.func
+    onVolumeChangeRequested: PropTypes.func,
+    muted: PropTypes.bool,
 };
 
 module.exports = VolumeSlider;


### PR DESCRIPTION
Set volume:

![Screenshot from 2025-02-06 12-15-44](https://github.com/user-attachments/assets/cb013d6d-8e3b-4db6-9a57-34cc922ac998)

On mute shows 0 volume on the slider:
![Screenshot from 2025-02-06 12-15-48](https://github.com/user-attachments/assets/239a3d8c-39eb-4a12-9ce4-3ee929c9848a)

on unmute shows the same volume level:
![Screenshot from 2025-02-06 12-15-44](https://github.com/user-attachments/assets/cb013d6d-8e3b-4db6-9a57-34cc922ac998)

Another example:

![Screenshot from 2025-02-06 12-15-54](https://github.com/user-attachments/assets/02d981bc-9bf6-42d8-8e52-7621fda0b876)
![Screenshot from 2025-02-06 12-15-48](https://github.com/user-attachments/assets/239a3d8c-39eb-4a12-9ce4-3ee929c9848a)