### PR TITLE
Calendar: Fix items scroll in view to ensure borders remain visible

### DIFF
--- a/src/routes/Calendar/List/Item/Item.less
+++ b/src/routes/Calendar/List/Item/Item.less
@@ -7,8 +7,6 @@
     flex-direction: column;
     background-color: var(--overlay-color);
     border-radius: var(--border-radius);
-    border: 0.15rem solid transparent;
-    transition: border-color 0.1s ease-out;
 
     .heading {
         flex: none;
@@ -82,6 +80,19 @@
         }
     }
 
+    &::before {
+        border: 0.15rem solid transparent;
+        border-radius: var(--border-radius);
+        box-sizing: border-box;
+        content: "";
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        pointer-events: none;
+        z-index: 1;
+        transition: border-color 0.1s ease-out;
+    }
+
     &.today {
         .heading {
             background-color: var(--primary-accent-color);
@@ -89,7 +100,9 @@
     }
 
     &.active {
-        border-color: var(--primary-foreground-color);
+        &::before {
+            border-color: var(--primary-foreground-color);
+        }
     }
 
     &:not(.active):hover {

--- a/src/routes/Calendar/List/Item/Item.less
+++ b/src/routes/Calendar/List/Item/Item.less
@@ -9,7 +9,10 @@
     border-radius: var(--border-radius);
     border: 0.15rem solid transparent;
     transition: border-color 0.1s ease-out;
-    scroll-margin-block-start: 2px;
+
+    @supports (scroll-margin-block-start: 2px) {
+        scroll-margin-block-start: 2px;
+    }
 
     .heading {
         flex: none;

--- a/src/routes/Calendar/List/Item/Item.less
+++ b/src/routes/Calendar/List/Item/Item.less
@@ -7,6 +7,8 @@
     flex-direction: column;
     background-color: var(--overlay-color);
     border-radius: var(--border-radius);
+    border: 0.15rem solid transparent;
+    transition: border-color 0.1s ease-out;
 
     .heading {
         flex: none;
@@ -80,19 +82,6 @@
         }
     }
 
-    &::before {
-        border: 0.15rem solid transparent;
-        border-radius: var(--border-radius);
-        box-sizing: border-box;
-        content: "";
-        width: 100%;
-        height: 100%;
-        position: absolute;
-        pointer-events: none;
-        z-index: 1;
-        transition: border-color 0.1s ease-out;
-    }
-
     &.today {
         .heading {
             background-color: var(--primary-accent-color);
@@ -100,12 +89,16 @@
     }
 
     &.active {
-        &::before {
-            border-color: var(--primary-foreground-color);
-        }
+        border-color: var(--primary-foreground-color);
     }
 
     &:not(.active):hover {
         border-color: var(--overlay-color);
+    }
+}
+
+@supports (scroll-margin-block-start: 2px) {
+    .item {
+        scroll-margin-block-start: 2px;
     }
 }

--- a/src/routes/Calendar/List/Item/Item.less
+++ b/src/routes/Calendar/List/Item/Item.less
@@ -9,6 +9,7 @@
     border-radius: var(--border-radius);
     border: 0.15rem solid transparent;
     transition: border-color 0.1s ease-out;
+    scroll-margin-block-start: 2px;
 
     .heading {
         flex: none;
@@ -94,11 +95,5 @@
 
     &:not(.active):hover {
         border-color: var(--overlay-color);
-    }
-}
-
-@supports (scroll-margin-block-start: 2px) {
-    .item {
-        scroll-margin-block-start: 2px;
     }
 }

--- a/src/routes/Calendar/List/Item/Item.less
+++ b/src/routes/Calendar/List/Item/Item.less
@@ -10,10 +10,6 @@
     border: 0.15rem solid transparent;
     transition: border-color 0.1s ease-out;
 
-    @supports (scroll-margin-block-start: 2px) {
-        scroll-margin-block-start: 2px;
-    }
-
     .heading {
         flex: none;
         position: relative;

--- a/src/routes/Calendar/List/List.less
+++ b/src/routes/Calendar/List/List.less
@@ -10,6 +10,7 @@
     width: 20rem;
     padding: 0 1rem;
     overflow-y: auto;
+    scroll-padding-block-start: 2px;
 }
 
 @media only screen and (max-width: @small) and (orientation: portrait) {
@@ -33,11 +34,5 @@
 @media only screen and (max-width: @xsmall) and (orientation: landscape) {
     .list {
         display: none;
-    }
-}
-
-@supports (scroll-padding-block-start: 2px) {
-    .list {
-        scroll-padding-block-start: 2px;
     }
 }

--- a/src/routes/Calendar/List/List.less
+++ b/src/routes/Calendar/List/List.less
@@ -35,3 +35,9 @@
         display: none;
     }
 }
+
+@supports (scroll-padding-block-start: 2px) {
+    .list {
+        scroll-padding-block-start: 2px;
+    }
+}

--- a/src/routes/Calendar/List/List.less
+++ b/src/routes/Calendar/List/List.less
@@ -10,7 +10,10 @@
     width: 20rem;
     padding: 0 1rem;
     overflow-y: auto;
-    scroll-padding-block-start: 2px;
+    
+    @supports (scroll-padding-block-start: 2px) {
+        scroll-padding-block-start: 2px;
+    }
 }
 
 @media only screen and (max-width: @small) and (orientation: portrait) {

--- a/src/routes/Calendar/List/List.less
+++ b/src/routes/Calendar/List/List.less
@@ -11,8 +11,8 @@
     padding: 0 1rem;
     overflow-y: auto;
     
-    @supports (scroll-padding-block-start: 2px) {
-        scroll-padding-block-start: 2px;
+    @supports (scroll-padding-block-start: 0.15rem) {
+        scroll-padding-block-start: 0.15rem;
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue where calendar list items were partially hidden when scrolled into view. The issue was caused by how some browsers handles `scrollIntoView({ block: 'start' })`, which sometimes ignores borders and padding.

Used scroll margin/padding block at the start

Closes [Issue #372](https://github.com/Stremio/stremio-tasks/issues/372)