### PR TITLE
fix(Calendar): iPad Safari styles

### DIFF
--- a/src/routes/Calendar/Calendar.less
+++ b/src/routes/Calendar/Calendar.less
@@ -13,7 +13,7 @@
         gap: 0.5rem;
         width: 100%;
         height: 100%;
-        padding: 0 0 calc(1.5rem + var(--safe-area-inset-bottom)) 2rem;
+        padding: 0 0 2rem;
 
         .main {
             flex: auto;
@@ -36,7 +36,7 @@
 @media only screen and (max-width: @small) and (orientation: landscape) {
     .calendar {
         .content {
-            padding: 0 0 calc(1.5rem + var(--safe-area-inset-bottom)) 1rem;
+            padding: 0 0 1rem;
         }
     }
 }

--- a/src/routes/Calendar/Calendar.less
+++ b/src/routes/Calendar/Calendar.less
@@ -13,7 +13,7 @@
         gap: 0.5rem;
         width: 100%;
         height: 100%;
-        padding: 0 0 2rem;
+        padding: 0 0 1.5rem 1.5rem;
 
         .main {
             flex: auto;
@@ -29,14 +29,6 @@
     .calendar {
         .content {
             padding: 0;
-        }
-    }
-}
-
-@media only screen and (max-width: @small) and (orientation: landscape) {
-    .calendar {
-        .content {
-            padding: 0 0 1rem;
         }
     }
 }


### PR DESCRIPTION
After some changes in handling the `nav-content` the additional padding was not needed anymore