### PR TITLE
App: remove edges blank space 

### DIFF
--- a/src/components/MainNavBars/MainNavBars.less
+++ b/src/components/MainNavBars/MainNavBars.less
@@ -34,7 +34,7 @@
         bottom: 0;
         left: var(--vertical-nav-bar-size);
         z-index: 0;
-        overflow: scroll;
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
Scrollbars were forced to be shown causing a blank space at the edges of the viewport