### PR TITLE
Player: improve volume indicator

### DIFF
--- a/src/routes/Player/ControlBar/ControlBar.js
+++ b/src/routes/Player/ControlBar/ControlBar.js
@@ -129,9 +129,10 @@ const ControlBar = ({
                         name={
                             (typeof muted === 'boolean' && muted) ? 'volume-mute' :
                                 (volume === null || isNaN(volume)) ? 'volume-off' :
-                                    volume < 30 ? 'volume-low' :
-                                        volume < 70 ? 'volume-medium' :
-                                            'volume-high'
+                                    volume === 0 ? 'volume-mute' :
+                                        volume < 30 ? 'volume-low' :
+                                            volume < 70 ? 'volume-medium' :
+                                                'volume-high'
                         }
                     />
                 </Button>

--- a/src/routes/Player/VolumeChangeIndicator/VolumeChangeIndicator.js
+++ b/src/routes/Player/VolumeChangeIndicator/VolumeChangeIndicator.js
@@ -14,11 +14,12 @@ const VolumeChangeIndicator = React.memo(({ muted, volume }) => {
     const prevVolume = React.useRef(volume);
 
     const iconName = React.useMemo(() => {
-        return typeof muted === 'boolean' && muted ? 'volume-mute' :
+        return (typeof muted === 'boolean' && muted) ? 'volume-mute' :
             volume === null || isNaN(volume) ? 'volume-off' :
-                volume < 30 ? 'volume-low' :
-                    volume < 70 ? 'volume-medium' :
-                        'volume-high';
+                volume === 0 ? 'volume-mute' :
+                    volume < 30 ? 'volume-low' :
+                        volume < 70 ? 'volume-medium' :
+                            'volume-high';
     }, [muted, volume]);
 
     React.useEffect(() => {


### PR DESCRIPTION
Apart from muting directly the volume, when you lower the volume to 0 it was not showing the icon for `muted`.
This PR addresses this issue in both the Volume indicator (when full-screen with no control bar) and the control bar volume icon