### PR TITLE
Details: fix Imdb button visual bug

### DIFF
--- a/src/components/MetaPreview/styles.less
+++ b/src/components/MetaPreview/styles.less
@@ -107,7 +107,9 @@
                 display: flex;
                 flex-direction: row;
                 align-items: center;
-                border-radius: 2.5rem;
+                border-radius: 0.5rem;
+                border: var(--focus-outline-size) solid transparent;
+                padding: 0rem 0.5rem;
 
                 &:focus {
                     outline: none;


### PR DESCRIPTION
Resolves a visual flicker issue when inside MetaDetails Imdb button receives focus. The bug was caused by inconsistent styling during the focus state.

Closes [Issue #434](https://github.com/Stremio/stremio-tasks/issues/434)