### PR TITLE
Player(Shell): Fix binge watching bugs

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -218,9 +218,9 @@ const Player = ({ urlParams, queryParams }) => {
             const deepLinks = player.nextVideo.deepLinks;
             const navigateToPlayer = deepLinks.player ? deepLinks.player : null;
             const navigateToDetails = deepLinks.metaDetailsStreams ? deepLinks.metaDetailsStreams : null;
-            
+    
             nextVideo();
-            
+    
             requestAnimationFrame(() => {
                 if (navigateToPlayer) {
                     window.location.replace(navigateToPlayer);

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -216,12 +216,12 @@ const Player = ({ urlParams, queryParams }) => {
     const onNextVideoRequested = React.useCallback(() => {
         if (player.nextVideo !== null) {
             nextVideo();
-
             const deepLinks = player.nextVideo.deepLinks;
-            if (deepLinks.metaDetailsStreams && deepLinks.player) {
+
+            if (deepLinks.player) {
                 window.location.replace(deepLinks.player);
-            } else {
-                window.location.replace(deepLinks.player ?? deepLinks.metaDetailsStreams);
+            } else if (deepLinks.metaDetailsStreams) {
+                window.location.replace(deepLinks.metaDetailsStreams);
             }
         }
     }, [player.nextVideo]);

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -120,7 +120,7 @@ const Player = ({ urlParams, queryParams }) => {
         if (isNavigating.current) {
             return;
         }
-        
+
         ended();
         if (player.nextVideo !== null) {
             nextVideo();

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -123,13 +123,11 @@ const Player = ({ urlParams, queryParams }) => {
 
         ended();
         if (player.nextVideo !== null) {
-            nextVideo();
-            const deepLinks = player.nextVideo.deepLinks;
-            handleNextVideoNavigation(deepLinks);
+            onNextVideoRequested();
         } else {
             window.history.back();
         }
-    }, [player.nextVideo, nextVideo, handleNextVideoNavigation]);
+    }, [player.nextVideo, onNextVideoRequested]);
 
     const onError = React.useCallback((error) => {
         console.error('Player', error);

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -102,6 +102,7 @@ const Player = ({ urlParams, queryParams }) => {
     }, [settings.subtitlesSize, settings.subtitlesOffset, settings.subtitlesTextColor, settings.subtitlesBackgroundColor, settings.subtitlesOutlineColor]);
 
     const onEnded = React.useCallback(() => {
+        console.log('Player in on ended callback', player.nextVideo); // eslint-disable-line no-console
         ended();
         if (player.nextVideo !== null) {
             onNextVideoRequested();
@@ -215,19 +216,26 @@ const Player = ({ urlParams, queryParams }) => {
 
     const onNextVideoRequested = React.useCallback(() => {
         if (player.nextVideo !== null) {
-            const deepLinks = player.nextVideo.deepLinks;
-            const navigateToPlayer = deepLinks.player ? deepLinks.player : null;
-            const navigateToDetails = deepLinks.metaDetailsStreams ? deepLinks.metaDetailsStreams : null;
+            const navigationData = {
+                playerLink: player.nextVideo.deepLinks.player,
+                metaDetailsLink: player.nextVideo.deepLinks.metaDetailsStreams
+            };
 
-            nextVideo();
-
-            requestAnimationFrame(() => {
-                if (navigateToPlayer) {
-                    window.location.replace(navigateToPlayer);
-                } else if (navigateToDetails) {
-                    window.location.replace(navigateToDetails);
-                }
-            });
+            if (navigationData.playerLink) {
+                requestAnimationFrame(() => {
+                    window.location.replace(navigationData.playerLink);
+                });
+                setTimeout(() => {
+                    nextVideo();
+                }, 500);
+            } else if (navigationData.metaDetailsLink) {
+                requestAnimationFrame(() => {
+                    window.location.replace(navigationData.metaDetailsLink);
+                });
+                setTimeout(() => {
+                    nextVideo();
+                }, 500);
+            }
         }
     }, [player.nextVideo]);
 
@@ -628,6 +636,10 @@ const Player = ({ urlParams, queryParams }) => {
         onEnded,
         onImplementationChanged
     ]);
+
+    React.useEffect(() => {
+        console.log('Player next video in use effect', player.nextVideo); // eslint-disable-line no-console
+    }, [player.nextVideo]);
 
     React.useLayoutEffect(() => {
         return () => {

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -219,7 +219,7 @@ const Player = ({ urlParams, queryParams }) => {
 
             const deepLinks = player.nextVideo.deepLinks;
             if (deepLinks.metaDetailsStreams && deepLinks.player) {
-                window.location.href = deepLinks.player;
+                window.location.replace(deepLinks.player);
             } else {
                 window.location.replace(deepLinks.player ?? deepLinks.metaDetailsStreams);
             }
@@ -620,11 +620,7 @@ const Player = ({ urlParams, queryParams }) => {
             video.events.off('implementationChanged', onImplementationChanged);
         };
     }, [
-        onError,
         onEnded,
-        onSubtitlesTrackLoaded,
-        onExtraSubtitlesTrackLoaded,
-        onExtraSubtitlesTrackAdded,
         onImplementationChanged
     ]);
 

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -505,7 +505,7 @@ const Player = ({ urlParams, queryParams }) => {
             video.events.off('extraSubtitlesTrackAdded', onExtraSubtitlesTrackAdded);
             video.events.off('implementationChanged', onImplementationChanged);
         };
-    }, [onEnded]);
+    }, []);
 
     React.useLayoutEffect(() => {
         const onKeyDown = (event) => {

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -107,13 +107,10 @@ const Player = ({ urlParams, queryParams }) => {
         if (deepLinks.player) {
             isNavigating.current = true;
             window.location.replace(deepLinks.player);
-            return true;
         } else if (deepLinks.metaDetailsStreams) {
             isNavigating.current = true;
             window.location.replace(deepLinks.metaDetailsStreams);
-            return true;
         }
-        return false;
     }, []);
 
     const onEnded = React.useCallback(() => {

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -215,14 +215,19 @@ const Player = ({ urlParams, queryParams }) => {
 
     const onNextVideoRequested = React.useCallback(() => {
         if (player.nextVideo !== null) {
-            nextVideo();
             const deepLinks = player.nextVideo.deepLinks;
-
-            if (deepLinks.player) {
-                window.location.replace(deepLinks.player);
-            } else if (deepLinks.metaDetailsStreams) {
-                window.location.replace(deepLinks.metaDetailsStreams);
-            }
+            const navigateToPlayer = deepLinks.player ? deepLinks.player : null;
+            const navigateToDetails = deepLinks.metaDetailsStreams ? deepLinks.metaDetailsStreams : null;
+            
+            nextVideo();
+            
+            requestAnimationFrame(() => {
+                if (navigateToPlayer) {
+                    window.location.replace(navigateToPlayer);
+                } else if (navigateToDetails) {
+                    window.location.replace(navigateToDetails);
+                }
+            });
         }
     }, [player.nextVideo]);
 

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -83,7 +83,6 @@ const Player = ({ urlParams, queryParams }) => {
         return immersed && !casting && video.state.paused !== null && !video.state.paused && !menusOpen && !nextVideoPopupOpen;
     }, [immersed, casting, video.state.paused, menusOpen, nextVideoPopupOpen]);
 
-    const nextVideoHandledRef = React.useRef(false);
     const nextVideoPopupDismissed = React.useRef(false);
     const nextVideoInitialData = React.useRef(player.nextVideo);
     nextVideoInitialData.current = player.nextVideo;
@@ -220,6 +219,7 @@ const Player = ({ urlParams, queryParams }) => {
     const onNextVideoRequested = React.useCallback(() => {
         if (player.nextVideo !== null) {
             nextVideo();
+
             const deepLinks = player.nextVideo.deepLinks;
             if (deepLinks.metaDetailsStreams && deepLinks.player) {
                 window.location.replace(deepLinks.metaDetailsStreams);
@@ -421,7 +421,6 @@ const Player = ({ urlParams, queryParams }) => {
         defaultSubtitlesSelected.current = false;
         defaultAudioTrackSelected.current = false;
         nextVideoPopupDismissed.current = false;
-        nextVideoHandledRef.current = false;
     }, [video.state.stream]);
 
     React.useEffect(() => {
@@ -484,28 +483,6 @@ const Player = ({ urlParams, queryParams }) => {
             onPauseRequested();
         }
     }, [settings.pauseOnMinimize, shell.windowClosed, shell.windowHidden]);
-
-    React.useEffect(() => {
-        nextVideoHandledRef.current = false;
-    }, [player.selected]);
-
-    React.useEffect(() => {
-        video.events.on('error', onError);
-        video.events.on('ended', onEnded);
-        video.events.on('subtitlesTrackLoaded', onSubtitlesTrackLoaded);
-        video.events.on('extraSubtitlesTrackLoaded', onExtraSubtitlesTrackLoaded);
-        video.events.on('extraSubtitlesTrackAdded', onExtraSubtitlesTrackAdded);
-        video.events.on('implementationChanged', onImplementationChanged);
-
-        return () => {
-            video.events.off('error', onError);
-            video.events.off('ended', onEnded);
-            video.events.off('subtitlesTrackLoaded', onSubtitlesTrackLoaded);
-            video.events.off('extraSubtitlesTrackLoaded', onExtraSubtitlesTrackLoaded);
-            video.events.off('extraSubtitlesTrackAdded', onExtraSubtitlesTrackAdded);
-            video.events.off('implementationChanged', onImplementationChanged);
-        };
-    }, []);
 
     React.useLayoutEffect(() => {
         const onKeyDown = (event) => {
@@ -629,6 +606,24 @@ const Player = ({ urlParams, queryParams }) => {
             window.removeEventListener('wheel', onWheel);
         };
     }, [player.metaItem, player.selected, streamingServer.statistics, settings.seekTimeDuration, settings.seekShortTimeDuration, settings.escExitFullscreen, routeFocused, menusOpen, nextVideoPopupOpen, video.state.paused, video.state.time, video.state.volume, video.state.audioTracks, video.state.subtitlesTracks, video.state.extraSubtitlesTracks, video.state.playbackSpeed, toggleSubtitlesMenu, toggleStatisticsMenu, toggleSideDrawer]);
+
+    React.useEffect(() => {
+        video.events.on('error', onError);
+        video.events.on('ended', onEnded);
+        video.events.on('subtitlesTrackLoaded', onSubtitlesTrackLoaded);
+        video.events.on('extraSubtitlesTrackLoaded', onExtraSubtitlesTrackLoaded);
+        video.events.on('extraSubtitlesTrackAdded', onExtraSubtitlesTrackAdded);
+        video.events.on('implementationChanged', onImplementationChanged);
+
+        return () => {
+            video.events.off('error', onError);
+            video.events.off('ended', onEnded);
+            video.events.off('subtitlesTrackLoaded', onSubtitlesTrackLoaded);
+            video.events.off('extraSubtitlesTrackLoaded', onExtraSubtitlesTrackLoaded);
+            video.events.off('extraSubtitlesTrackAdded', onExtraSubtitlesTrackAdded);
+            video.events.off('implementationChanged', onImplementationChanged);
+        };
+    }, []);
 
     React.useLayoutEffect(() => {
         return () => {

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -88,6 +88,8 @@ const Player = ({ urlParams, queryParams }) => {
     const defaultAudioTrackSelected = React.useRef(false);
     const [error, setError] = React.useState(null);
 
+    const isNavigating = React.useRef(false);
+
     const onImplementationChanged = React.useCallback(() => {
         video.setProp('subtitlesSize', settings.subtitlesSize);
         video.setProp('subtitlesOffset', settings.subtitlesOffset);
@@ -101,7 +103,24 @@ const Player = ({ urlParams, queryParams }) => {
         video.setProp('extraSubtitlesOutlineColor', settings.subtitlesOutlineColor);
     }, [settings.subtitlesSize, settings.subtitlesOffset, settings.subtitlesTextColor, settings.subtitlesBackgroundColor, settings.subtitlesOutlineColor]);
 
+    const handleNextVideoNavigation = React.useCallback((deepLinks) => {
+        if (deepLinks.player) {
+            isNavigating.current = true;
+            window.location.href = deepLinks.player;
+            return true;
+        } else if (deepLinks.metaDetailsStreams) {
+            isNavigating.current = true;
+            window.location.href = deepLinks.metaDetailsStreams;
+            return true;
+        }
+        return false;
+    }, []);
+
     const onEnded = React.useCallback(() => {
+        if (isNavigating.current) {
+            return;
+        }
+        
         ended();
         if (player.nextVideo !== null) {
             onNextVideoRequested();
@@ -218,14 +237,9 @@ const Player = ({ urlParams, queryParams }) => {
             nextVideo();
 
             const deepLinks = player.nextVideo.deepLinks;
-            if (deepLinks.metaDetailsStreams && deepLinks.player) {
-                window.location.replace(deepLinks.metaDetailsStreams);
-                window.location.href = deepLinks.player;
-            } else {
-                window.location.replace(deepLinks.player ?? deepLinks.metaDetailsStreams);
-            }
+            handleNextVideoNavigation(deepLinks);
         }
-    }, [player.nextVideo]);
+    }, [player.nextVideo, handleNextVideoNavigation]);
 
     const onVideoClick = React.useCallback(() => {
         if (video.state.paused !== null) {

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -219,7 +219,6 @@ const Player = ({ urlParams, queryParams }) => {
 
             const deepLinks = player.nextVideo.deepLinks;
             if (deepLinks.metaDetailsStreams && deepLinks.player) {
-                window.location.replace(deepLinks.metaDetailsStreams);
                 window.location.href = deepLinks.player;
             } else {
                 window.location.replace(deepLinks.player ?? deepLinks.metaDetailsStreams);

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -84,8 +84,6 @@ const Player = ({ urlParams, queryParams }) => {
     }, [immersed, casting, video.state.paused, menusOpen, nextVideoPopupOpen]);
 
     const nextVideoPopupDismissed = React.useRef(false);
-    const nextVideoInitialData = React.useRef(player.nextVideo);
-    nextVideoInitialData.current = player.nextVideo;
     const defaultSubtitlesSelected = React.useRef(false);
     const defaultAudioTrackSelected = React.useRef(false);
     const [error, setError] = React.useState(null);
@@ -104,7 +102,6 @@ const Player = ({ urlParams, queryParams }) => {
     }, [settings.subtitlesSize, settings.subtitlesOffset, settings.subtitlesTextColor, settings.subtitlesBackgroundColor, settings.subtitlesOutlineColor]);
 
     const onEnded = React.useCallback(() => {
-        player.nextVideo = nextVideoInitialData.current;
         ended();
         if (player.nextVideo !== null) {
             onNextVideoRequested();

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -218,9 +218,9 @@ const Player = ({ urlParams, queryParams }) => {
             const deepLinks = player.nextVideo.deepLinks;
             const navigateToPlayer = deepLinks.player ? deepLinks.player : null;
             const navigateToDetails = deepLinks.metaDetailsStreams ? deepLinks.metaDetailsStreams : null;
-    
+
             nextVideo();
-    
+
             requestAnimationFrame(() => {
                 if (navigateToPlayer) {
                     window.location.replace(navigateToPlayer);

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -123,11 +123,13 @@ const Player = ({ urlParams, queryParams }) => {
         
         ended();
         if (player.nextVideo !== null) {
-            onNextVideoRequested();
+            nextVideo();
+            const deepLinks = player.nextVideo.deepLinks;
+            handleNextVideoNavigation(deepLinks);
         } else {
             window.history.back();
         }
-    }, [player.nextVideo, onNextVideoRequested]);
+    }, [player.nextVideo, nextVideo, handleNextVideoNavigation]);
 
     const onError = React.useCallback((error) => {
         console.error('Player', error);

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -106,11 +106,11 @@ const Player = ({ urlParams, queryParams }) => {
     const handleNextVideoNavigation = React.useCallback((deepLinks) => {
         if (deepLinks.player) {
             isNavigating.current = true;
-            window.location.href = deepLinks.player;
+            window.location.replace(deepLinks.player);
             return true;
         } else if (deepLinks.metaDetailsStreams) {
             isNavigating.current = true;
-            window.location.href = deepLinks.metaDetailsStreams;
+            window.location.replace(deepLinks.metaDetailsStreams);
             return true;
         }
         return false;


### PR DESCRIPTION
- [x] Fix for https://github.com/Stremio/stremio-web/pull/895 since it broke the player logic and made the player jump 2 or even 3 episodes when binge watching
- [x] Fixes Shell next video / binge watching redirecting to `metaDetailsStreams` even when `player` was available.
- [x] Fixes the navigation history when using binge watching (now if you start watching at episode 1 and binge watch till eg. episode 7, when you click the back button you will get back to episode 1 streams directly)

## TODO in next PR
- Fix Player not redirecting `onEnded` of next episode (basically when you do nothing and the stream ends nothing is happening, you should get redirected to next episode as well or back to streams page) / `metaDetailsStreams`
