### PR TITLE
Player: Fix mobile layout for side drawer

### DIFF
--- a/src/components/MultiselectMenu/Dropdown/Dropdown.less
+++ b/src/components/MultiselectMenu/Dropdown/Dropdown.less
@@ -2,7 +2,7 @@
 
 @import (reference) '~stremio/common/screen-sizes.less';
 
-@parent-height: 10rem;
+@parent-height: 12rem;
 
 .dropdown {
     background: var(--modal-background-color);

--- a/src/routes/Player/SideDrawer/SideDrawer.less
+++ b/src/routes/Player/SideDrawer/SideDrawer.less
@@ -78,12 +78,6 @@
     }
 }
 
-@media screen and (max-width: @small) {
-    .side-drawer {
-        max-width: 40dvw;
-    }
-}
-
 @media @phone-portrait {
     .side-drawer {
         max-width: 100dvw;


### PR DESCRIPTION
- on iPad vertical mode the `SideDrawer` was clustered to the right
- on iPhone horizontal mode the `Dropdown` was being cut down by `2rem` and not entirely visible

<img height="150" alt="image" src="https://github.com/user-attachments/assets/2ba514d6-38f4-4a2b-9e75-baefd1832315" />

<img height="150" alt="Screenshot 2025-06-14 at 18 29 03" src="https://github.com/user-attachments/assets/2245c15f-814c-4b90-88b6-76902c83430b" />
