### PR TITLE
fix: Player - TimeChanged & Seek time & duration now have Math.max(0, x)

### DIFF
--- a/src/routes/Player/usePlayer.js
+++ b/src/routes/Player/usePlayer.js
@@ -103,7 +103,7 @@ const usePlayer = (urlParams) => {
                     action: 'TimeChanged',
                     args: {
                         time: Math.max(0, Math.round(time)),
-                        duration,
+                        duration: Math.max(0, Math.round(duration)),
                         device,
                     }
                 }
@@ -119,7 +119,7 @@ const usePlayer = (urlParams) => {
                     action: 'Seek',
                     args: {
                         time: Math.max(0, Math.round(time)),
-                        duration,
+                        duration: Math.max(0, Math.round(duration)),
                         device,
                     }
                 }

--- a/src/routes/Player/usePlayer.js
+++ b/src/routes/Player/usePlayer.js
@@ -102,7 +102,7 @@ const usePlayer = (urlParams) => {
                 args: {
                     action: 'TimeChanged',
                     args: {
-                        time: Math.round(time),
+                        time: Math.max(0, Math.round(time)),
                         duration,
                         device,
                     }
@@ -118,7 +118,7 @@ const usePlayer = (urlParams) => {
                 args: {
                     action: 'Seek',
                     args: {
-                        time: Math.round(time),
+                        time: Math.max(0, Math.round(time)),
                         duration,
                         device,
                     }


### PR DESCRIPTION
> dispatch failed because of Action: Error("invalid value: integer `-2225`, expected u64", line: 1, column: 63)

It happened in the player, it's some sort of an edge case but it could be the `duration` field as well.
I'm adding additional inspection log when the action fails due to deserialiation in core-web when dispatching so we will be able to debug such issues in the near future.