### PR TITLE
Update SearchParamsHandler.js

### DIFF
--- a/src/App/SearchParamsHandler.js
+++ b/src/App/SearchParamsHandler.js
@@ -36,7 +36,13 @@ const SearchParamsHandler = () => {
                     },
                 },
             });
-
+            core.transport.dispatch({
+                action: 'Ctx',
+                args: {
+                    action: 'AddServerUrl',
+                    args: streamingServerUrl,
+                },
+            });
             toast.show({
                 type: 'success',
                 title: `Using streaming server at ${streamingServerUrl}`,


### PR DESCRIPTION
Currently the streamingServerUrl query will add the new server URL, but under Settings->Streaming section the new URL is not shown, in the selection list with status indicator. As a result the yellow popup still appears stating that the server cannot be reached.

<img width="1000" height="627" alt="image" src="https://github.com/user-attachments/assets/c1c35396-59be-4857-9562-37a49d1be234" />