### PR TITLE
MetaPreview: MetaActions Button positioning fix

### DIFF
--- a/src/components/MetaPreview/ActionButton/styles.less
+++ b/src/components/MetaPreview/ActionButton/styles.less
@@ -65,7 +65,6 @@
         padding: 0 1rem;
 
         .icon-container {
-            height: 2rem;
             width: 2rem;
         }
     }

--- a/src/components/MetaPreview/styles.less
+++ b/src/components/MetaPreview/styles.less
@@ -240,6 +240,10 @@
                 border-radius: 2rem;
             }
         }
+
+        .ratings {
+            margin-right: 0;
+        }
     }
 }
 


### PR DESCRIPTION
check `@phone-landscape` before and after the change styles + mobile icon fixes