### PR TITLE
Search: dynamic view calculation fix on PWA

### DIFF
--- a/src/routes/Search/styles.less
+++ b/src/routes/Search/styles.less
@@ -12,7 +12,7 @@
 }
 
 .search-container {
-    height: 100%;
+    height: calc(100% - var(--safe-area-inset-bottom));
     width: 100%;
     background-color: transparent;
 


### PR DESCRIPTION
on search page the content height was not calculated correctly which caused the navbar to not follow the safe area insets on iOS PWA