### PR TITLE
fix(Intro): make all text lowercase to match the rest

### DIFF
--- a/src/routes/Intro/Intro.js
+++ b/src/routes/Intro/Intro.js
@@ -387,7 +387,7 @@ const Intro = ({ queryParams }) => {
                     {
                         state.form === SIGNUP_FORM ?
                             <Button className={classnames(styles['form-button'], styles['login-form-button'])} onClick={switchFormOnClick}>
-                                <div className={classnames(styles['label'], styles['uppercase'])}>{t('LOG_IN')}</div>
+                                <div className={classnames(styles['label'], styles['lowercase'])}>{t('LOG_IN')}</div>
                             </Button>
                             :
                             null
@@ -395,7 +395,7 @@ const Intro = ({ queryParams }) => {
                     {
                         state.form === LOGIN_FORM ?
                             <Button className={classnames(styles['form-button'], styles['signup-form-button'])} onClick={switchFormOnClick}>
-                                <div className={classnames(styles['label'], styles['uppercase'])}>{t('SIGN_UP_EMAIL')}</div>
+                                <div className={classnames(styles['label'], styles['lowercase'])}>{t('SIGN_UP_EMAIL')}</div>
                             </Button>
                             :
                             null
@@ -403,7 +403,7 @@ const Intro = ({ queryParams }) => {
                     {
                         state.form === SIGNUP_FORM ?
                             <Button className={classnames(styles['form-button'], styles['guest-login-button'])} onClick={loginAsGuest}>
-                                <div className={classnames(styles['label'], styles['uppercase'])}>{t('GUEST_LOGIN')}</div>
+                                <div className={classnames(styles['label'], styles['lowercase'])}>{t('GUEST_LOGIN')}</div>
                             </Button>
                             :
                             null


### PR DESCRIPTION
## What I changed
- Converted button text to lowercase where needed in Intro.js to ensure consistent casing on the page

## Why
- Some buttons had uppercase text and some had title text

## How I tested
- Manually verified the sign up/login page in a dev build.
- Confirmed buttons now display with consistent casing

## Files changed
- 'Intro.js'

## Related issue
- **Closes #1000**

 