### PR TITLE
Fixes #989: add mark-as-watched (discover + details)

### DIFF
--- a/src/components/MetaItem/MetaItem.js
+++ b/src/components/MetaItem/MetaItem.js
@@ -61,8 +61,10 @@ const MetaItem = React.memo(({ className, type, name, poster, posterShape, poste
     const renderMenuLabelContent = React.useCallback(() => (
         <Icon className={styles['icon']} name={'more-vertical'} />
     ), []);
+    const hasMenu = Array.isArray(options) && options.length > 0;
+
     return (
-        <Button title={name} href={href} {...filterInvalidDOMProps(props)} className={classnames(className, styles['meta-item-container'], styles['poster-shape-poster'], styles[`poster-shape-${posterShape}`], { 'active': menuOpen })} onClick={metaItemOnClick}>
+        <Button title={name} href={href} {...filterInvalidDOMProps(props)} className={classnames(className, styles['meta-item-container'], styles['poster-shape-poster'], styles[`poster-shape-${posterShape}`], { 'active': menuOpen, 'has-menu': hasMenu })} onClick={metaItemOnClick}>
             <div className={classnames(styles['poster-container'], { 'poster-change-cursor': posterChangeCursor })}>
                 {
                     onDismissClick ?

--- a/src/components/MetaItem/styles.less
+++ b/src/components/MetaItem/styles.less
@@ -53,6 +53,15 @@
         }
     }
 
+    &.has-menu {
+        .title-bar-container {
+            .menu-label-container {
+                opacity: 1;
+                transform: none;
+            }
+        }
+    }
+
     &.poster-shape-poster {
         .poster-container {
             padding-top: calc(100% * var(--poster-shape-ratio));

--- a/src/components/MetaPreview/MetaPreview.js
+++ b/src/components/MetaPreview/MetaPreview.js
@@ -10,6 +10,7 @@ const { default: Button } = require('stremio/components/Button');
 const { default: Image } = require('stremio/components/Image');
 const ModalDialog = require('stremio/components/ModalDialog');
 const SharePrompt = require('stremio/components/SharePrompt');
+const { useServices } = require('stremio/services');
 const CONSTANTS = require('stremio/common/CONSTANTS');
 const routesRegexp = require('stremio/common/routesRegexp');
 const useBinaryState = require('stremio/common/useBinaryState');
@@ -25,8 +26,9 @@ const ALLOWED_LINK_REDIRECTS = [
     routesRegexp.metadetails.regexp
 ];
 
-const MetaPreview = React.forwardRef(({ className, compact, name, logo, background, runtime, releaseInfo, released, description, deepLinks, links, trailerStreams, inLibrary, toggleInLibrary, ratingInfo }, ref) => {
+const MetaPreview = React.forwardRef(({ className, compact, name, logo, background, runtime, releaseInfo, released, description, deepLinks, links, trailerStreams, inLibrary, toggleInLibrary, ratingInfo, metaId, libraryItem, watched }, ref) => {
     const { t } = useTranslation();
+    const { core } = useServices();
     const [shareModalOpen, openShareModal, closeShareModal] = useBinaryState(false);
     const linksGroups = React.useMemo(() => {
         return Array.isArray(links) ?
@@ -73,6 +75,26 @@ const MetaPreview = React.forwardRef(({ className, compact, name, logo, backgrou
             :
             new Map();
     }, [links]);
+    const normalizeWatched = React.useCallback((val) => {
+        let v = val;
+        while (v && typeof v === 'object' && ('value' in v || 'val' in v)) {
+            v = v.value ?? v.val;
+        }
+
+        if (v === true || v === 'true') return true;
+        if (v === false || v === 'false') return false;
+        if (typeof v === 'number') return v !== 0;
+        if (typeof v === 'string') {
+            const s = v.trim();
+            if (s === '0') return false;
+            if (s === '1') return true;
+            if (s.length === 0) return false;
+            return s.toLowerCase() !== 'false';
+        }
+
+        return !!v;
+    }, []);
+
     const showHref = React.useMemo(() => {
         return deepLinks ?
             typeof deepLinks.player === 'string' ?
@@ -88,6 +110,37 @@ const MetaPreview = React.forwardRef(({ className, compact, name, logo, backgrou
             :
             null;
     }, [deepLinks]);
+    const pendingMarkRef = React.useRef(null);
+    const [optimisticWatched, setOptimisticWatched] = React.useState(null);
+
+    React.useEffect(() => {
+        if (!pendingMarkRef.current) return;
+        const pending = pendingMarkRef.current;
+        // If we now have a libraryItem._id or metaId, dispatch the mark action
+        if ((libraryItem && libraryItem._id) || metaId) {
+            const id = (libraryItem && libraryItem._id) || metaId;
+            core.transport.dispatch({
+                action: 'Ctx',
+                args: {
+                    action: 'LibraryItemMarkAsWatched',
+                    args: {
+                        id,
+                        is_watched: pending.is_watched
+                    }
+                }
+            });
+            pendingMarkRef.current = null;
+        }
+    }, [libraryItem, metaId, core.transport]);
+
+    React.useEffect(() => {
+        const curStateVal = (libraryItem && libraryItem.state && (libraryItem.state.watched ?? libraryItem.state.is_watched)) ?? watched;
+        const actual = normalizeWatched(curStateVal);
+        if (optimisticWatched !== null && optimisticWatched !== actual) {
+            // authoritative state differs from optimistic — sync
+            setOptimisticWatched(null);
+        }
+    }, [libraryItem, watched, normalizeWatched]);
     const trailerHref = React.useMemo(() => {
         if (!Array.isArray(trailerStreams) || trailerStreams.length === 0) {
             return null;
@@ -235,10 +288,75 @@ const MetaPreview = React.forwardRef(({ className, compact, name, logo, backgrou
                 }
                 {
                     !compact && ratingInfo !== null ?
-                        <Ratings
-                            ratingInfo={ratingInfo}
-                            className={styles['ratings']}
-                        />
+                        <React.Fragment>
+                            <Ratings
+                                ratingInfo={ratingInfo}
+                                className={styles['ratings']}
+                            />
+                            {
+                                (libraryItem || typeof inLibrary === 'boolean') ?
+                                    <div className={styles['watched-container']}>
+                                        <Button
+                                            className={styles['eye-button']}
+                                            title={(function () {
+                                                const cur = (libraryItem && libraryItem.state && (libraryItem.state.watched ?? libraryItem.state.is_watched)) ?? watched;
+                                                const actual = normalizeWatched(cur);
+                                                const display = optimisticWatched !== null ? optimisticWatched : actual;
+                                                return display ? t('CTX_MARK_NON_WATCHED') : t('CTX_MARK_WATCHED');
+                                            })()}
+                                            onClick={() => {
+                                                const curStateVal = (libraryItem && libraryItem.state && (libraryItem.state.watched ?? libraryItem.state.is_watched)) ?? watched;
+                                                const actualWatched = normalizeWatched(curStateVal);
+                                                const targetWatched = !actualWatched;
+
+                                                if (typeof inLibrary === 'boolean' && inLibrary && metaId) {
+                                                    core.transport.dispatch({
+                                                        action: 'Ctx',
+                                                        args: {
+                                                            action: 'LibraryItemMarkAsWatched',
+                                                            args: {
+                                                                id: metaId,
+                                                                is_watched: targetWatched
+                                                            }
+                                                        }
+                                                    });
+                                                    setOptimisticWatched(targetWatched);
+                                                    return;
+                                                }
+
+                                                if (libraryItem && libraryItem._id) {
+                                                    core.transport.dispatch({
+                                                        action: 'Ctx',
+                                                        args: {
+                                                            action: 'LibraryItemMarkAsWatched',
+                                                            args: {
+                                                                id: libraryItem._id,
+                                                                is_watched: targetWatched
+                                                            }
+                                                        }
+                                                    });
+                                                    setOptimisticWatched(targetWatched);
+                                                    return;
+                                                }
+
+                                                if (typeof toggleInLibrary === 'function') {
+                                                    pendingMarkRef.current = { is_watched: targetWatched };
+                                                    setOptimisticWatched(targetWatched);
+                                                    toggleInLibrary();
+                                                }
+                                            }}
+                                        >
+                                            {(() => {
+                                                const cur = (libraryItem && libraryItem.state && (libraryItem.state.watched ?? libraryItem.state.is_watched)) ?? watched;
+                                                const actualWatched = normalizeWatched(cur);
+                                                const displayWatched = optimisticWatched !== null ? optimisticWatched : actualWatched;
+                                                return <Icon className={styles['icon']} name={displayWatched ? 'eye-off' : 'eye'} />;
+                                            })()}
+                                        </Button>
+                                    </div>
+                                    : null
+                            }
+                        </React.Fragment>
                         :
                         null
                 }
@@ -299,6 +417,12 @@ MetaPreview.propTypes = {
     inLibrary: PropTypes.bool,
     toggleInLibrary: PropTypes.func,
     ratingInfo: PropTypes.object,
+    metaId: PropTypes.string,
+    libraryItem: PropTypes.shape({
+        _id: PropTypes.string,
+        state: PropTypes.object
+    }),
+    watched: PropTypes.bool,
 };
 
 module.exports = MetaPreview;

--- a/src/components/MetaPreview/styles.less
+++ b/src/components/MetaPreview/styles.less
@@ -213,6 +213,41 @@
         margin-bottom: 1rem;
         margin-right: 1rem;
     }
+
+    .watched-container {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 1rem;
+        /* match spacing used between action buttons */
+        margin-right: 1rem;
+    }
+
+    .eye-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 4rem;
+        height: 4rem;
+        border-radius: 100%;
+        background-color: var(--overlay-color);
+        backdrop-filter: blur(5px);
+        transition: background-color 0.1s ease-out;
+
+        &:hover, &:focus {
+            outline: var(--focus-outline-size) solid var(--primary-foreground-color);
+            background-color: transparent;
+        }
+    }
+
+    .icon {
+        display: block;
+        width: 1.75rem;
+        height: 1.75rem;
+        color: var(--primary-foreground-color);
+        opacity: 0.9;
+    }
+
 }
 
 .share-prompt {

--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -157,21 +157,104 @@ const Discover = ({ urlParams, queryParams }) => {
                                     </div>
                                     :
                                     <div ref={metasContainerRef} className={classnames(styles['meta-items-container'], 'animation-fade-in')} onScroll={onScroll} onFocusCapture={metaItemsOnFocusCapture}>
-                                        {discover.catalog.content.content.map((metaItem, index) => (
-                                            <MetaItem
-                                                key={index}
-                                                className={classnames({ 'selected': selectedMetaItemIndex === index })}
-                                                type={metaItem.type}
-                                                name={metaItem.name}
-                                                poster={metaItem.poster}
-                                                posterShape={metaItem.posterShape}
-                                                playname={selectedMetaItemIndex === index}
-                                                deepLinks={metaItem.deepLinks}
-                                                watched={metaItem.watched}
-                                                data-index={index}
-                                                onClick={metaItemOnClick}
-                                            />
-                                        ))}
+                                        {discover.catalog.content.content.map((metaItem, index) => {
+                                            const options = [
+                                                { label: 'LIBRARY_PLAY', value: 'play' },
+                                                { label: 'LIBRARY_DETAILS', value: 'details' },
+                                                { label: metaItem.watched ? 'CTX_MARK_UNWATCHED' : 'CTX_MARK_WATCHED', value: 'watched' }
+                                            ].filter(({ value }) => {
+                                                switch (value) {
+                                                    case 'play':
+                                                        return metaItem.deepLinks && typeof metaItem.deepLinks.player === 'string';
+                                                    case 'details':
+                                                        return metaItem.deepLinks && (typeof metaItem.deepLinks.metaDetailsVideos === 'string' || typeof metaItem.deepLinks.metaDetailsStreams === 'string');
+                                                    case 'watched':
+                                                        return true;
+                                                }
+                                            }).map((option) => ({ ...option, label: t(option.label) }));
+
+                                            const optionOnSelect = (event) => {
+                                                if (event.nativeEvent && event.nativeEvent.optionSelectPrevented) {
+                                                    return;
+                                                }
+
+                                                switch (event.value) {
+                                                    case 'play': {
+                                                        if (metaItem.deepLinks && typeof metaItem.deepLinks.player === 'string') {
+                                                            window.location = metaItem.deepLinks.player;
+                                                        }
+
+                                                        break;
+                                                    }
+                                                    case 'details': {
+                                                        if (metaItem.deepLinks) {
+                                                            if (typeof metaItem.deepLinks.metaDetailsVideos === 'string') {
+                                                                window.location = metaItem.deepLinks.metaDetailsVideos;
+                                                            } else if (typeof metaItem.deepLinks.metaDetailsStreams === 'string') {
+                                                                window.location = metaItem.deepLinks.metaDetailsStreams;
+                                                            }
+                                                        }
+
+                                                        break;
+                                                    }
+                                                    case 'watched': {
+                                                        if (metaItem.inLibrary) {
+                                                            core.transport.dispatch({
+                                                                action: 'Ctx',
+                                                                args: {
+                                                                    action: 'LibraryItemMarkAsWatched',
+                                                                    args: {
+                                                                        id: metaItem.id,
+                                                                        is_watched: !metaItem.watched
+                                                                    }
+                                                                }
+                                                            });
+                                                        } else {
+                                                            core.transport.dispatch({
+                                                                action: 'Ctx',
+                                                                args: {
+                                                                    action: 'AddToLibrary',
+                                                                    args: metaItem
+                                                                }
+                                                            });
+
+                                                            setTimeout(() => {
+                                                                core.transport.dispatch({
+                                                                    action: 'Ctx',
+                                                                    args: {
+                                                                        action: 'LibraryItemMarkAsWatched',
+                                                                        args: {
+                                                                            id: metaItem.id,
+                                                                            is_watched: true
+                                                                        }
+                                                                    }
+                                                                });
+                                                            }, 300);
+                                                        }
+
+                                                        break;
+                                                    }
+                                                }
+                                            };
+
+                                            return (
+                                                <MetaItem
+                                                    key={index}
+                                                    className={classnames({ 'selected': selectedMetaItemIndex === index })}
+                                                    type={metaItem.type}
+                                                    name={metaItem.name}
+                                                    poster={metaItem.poster}
+                                                    posterShape={metaItem.posterShape}
+                                                    playname={selectedMetaItemIndex === index}
+                                                    deepLinks={metaItem.deepLinks}
+                                                    watched={metaItem.watched}
+                                                    data-index={index}
+                                                    onClick={metaItemOnClick}
+                                                    options={options}
+                                                    optionOnSelect={optionOnSelect}
+                                                />
+                                            );
+                                        })}
                                     </div>
                     }
                 </div>

--- a/src/routes/MetaDetails/MetaDetails.js
+++ b/src/routes/MetaDetails/MetaDetails.js
@@ -167,8 +167,10 @@ const MetaDetails = ({ urlParams, queryParams }) => {
                                             links={metaDetails.metaItem.content.content.links}
                                             trailerStreams={metaDetails.metaItem.content.content.trailerStreams}
                                             inLibrary={metaDetails.metaItem.content.content.inLibrary}
+                                            watched={metaDetails.metaItem.content.content.watched}
                                             toggleInLibrary={metaDetails.metaItem.content.content.inLibrary ? removeFromLibrary : addToLibrary}
                                             metaId={metaDetails.metaItem.content.content.id}
+                                            libraryItem={metaDetails.libraryItem}
                                             ratingInfo={metaDetails.ratingInfo}
                                         />
                                     </React.Fragment>

--- a/src/routes/MetaDetails/useMetaDetails.js
+++ b/src/routes/MetaDetails/useMetaDetails.js
@@ -26,7 +26,9 @@ const map = (metaDetails) => ({
                                 :
                                 NaN
                         ),
-                    }))
+                    })),
+                    watched: (metaDetails.libraryItem && metaDetails.libraryItem.state && (metaDetails.libraryItem.state.watched ?? metaDetails.libraryItem.state.is_watched)) ?? metaDetails.metaItem.content.content.watched,
+                    inLibrary: !!metaDetails.libraryItem,
                 }
             }
         }


### PR DESCRIPTION
Added marked as watched to Discover section.
<img width="1099" height="568" alt="image" src="https://github.com/user-attachments/assets/dc3400ad-801c-4c83-adf0-00fb6eabe2bc" />


In Details page, there is an icon to toggle the watched state as well
<img width="1064" height="231" alt="image" src="https://github.com/user-attachments/assets/ee2d83c6-081b-4da6-b12b-28394a88bfb0" />
