### PR TITLE
Dev: add option to disable service worker

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ i18n
 const root = ReactDOM.createRoot(document.getElementById('app'));
 root.render(<App />);
 
-if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator && process.env.SERVICE_WORKER_DISABLED !== 'true') {
     window.addEventListener('load', () => {
         navigator.serviceWorker.register('service-worker.js')
             .catch((registrationError) => {

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ i18n
 const root = ReactDOM.createRoot(document.getElementById('app'));
 root.render(<App />);
 
-if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator && process.env.SERVICE_WORKER_DISABLED !== 'true') {
+if (process.env.NODE_ENV === 'production' && process.env.SERVICE_WORKER_DISABLED !== 'true' && process.env.SERVICE_WORKER_DISABLED !== true && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {
         navigator.serviceWorker.register('service-worker.js')
             .catch((registrationError) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -213,6 +213,7 @@ module.exports = (env, argv) => ({
         new webpack.EnvironmentPlugin({
             SENTRY_DSN: null,
             ...env,
+            SERVICE_WORKER_DISABLED: false,
             DEBUG: argv.mode !== 'production',
             VERSION: pachageJson.version,
             COMMIT_HASH


### PR DESCRIPTION
### The Problem

When using middleware for authentication (e.g., authentik), the service worker's caching of the root page (`/`) can interfere with the authentication flow. If a user's session expires, the cached page is served, preventing the middleware from redirecting to the login page. This is particularly problematic in environments where the app and server are on the same domain.

This change addresses the issue reported in [GitHub Issue #986](https://github.com/Stremio/stremio-web/issues/986).

### The Solution

A `SERVICE_WORKER_DISABLED` environment variable has been added. When this variable is set to `'true'`, the application will skip the registration of the service worker. This allows authentication middleware to function as expected without interference from the cached root page.

### How to Use

To disable the service worker, set the following environment variable in your build environment:

`SERVICE_WORKER_DISABLED=true`

By default, if the variable is not set or is set to `false`, the service worker will be registered as usual.

### Code of Conduct
- [x] I agree

