### PR TITLE
Add hover preview functionality for MetaItem cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "globals": "^15.13.0",
         "html-webpack-plugin": "5.6.3",
         "jest": "29.7.0",
+        "json-format": "^1.0.1",
         "less": "4.2.1",
         "less-loader": "12.2.0",
         "mini-css-extract-plugin": "2.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@24.5.2)
+      json-format:
+        specifier: ^1.0.1
+        version: 1.0.1
       less:
         specifier: 4.2.1
         version: 4.2.1
@@ -3288,6 +3291,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-format@1.0.1:
+    resolution: {integrity: sha512-MoKIg/lBeQALqjYnqEanikfo3zBKRwclpXJexdF0FUniYAAN2ypEIXBEtpQb+9BkLFtDK1fyTLAsnGlyGfLGxw==}
 
   json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
@@ -9065,6 +9071,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-format@1.0.1: {}
 
   json-parse-better-errors@1.0.2: {}
 

--- a/src/components/HoverPreview/HoverPreview.js
+++ b/src/components/HoverPreview/HoverPreview.js
@@ -1,0 +1,104 @@
+// Copyright (C) 2017-2025 Smart code 203358507
+
+const React = require('react');
+const PropTypes = require('prop-types');
+const classnames = require('classnames');
+const { default: Icon } = require('@stremio/stremio-icons/react');
+const { default: Image } = require('stremio/components/Image');
+const { useTranslation } = require('react-i18next');
+const styles = require('./styles.less');
+
+const HoverPreview = ({ className, name, type, releaseInfo, runtime, description, genres, rating, position }) => {
+    const { t } = useTranslation();
+    const previewRef = React.useRef(null);
+    
+    // Position can be a combination of 'top'|'bottom' and 'left'|'center'|'right'
+    // Default is 'top-center'
+    const positionVertical = position?.includes('bottom') ? 'bottom' : 'top';
+    let positionHorizontal = 'center';
+    
+    if (position?.includes('left')) {
+        positionHorizontal = 'left';
+    } else if (position?.includes('right')) {
+        positionHorizontal = 'right';
+    }
+    
+    // Ensure preview stays within viewport bounds when it becomes visible
+    React.useEffect(() => {
+        const preview = previewRef.current;
+        if (!preview) return;
+        
+        // Check if preview extends beyond viewport and adjust if needed
+        const rect = preview.getBoundingClientRect();
+        const viewportWidth = window.innerWidth;
+        
+        // Adjust horizontal position if needed
+        if (rect.right > viewportWidth - 10) {
+            preview.style.left = 'auto';
+            preview.style.right = '0';
+            preview.style.transform = 'translateX(0)';
+        } else if (rect.left < 10) {
+            preview.style.left = '0';
+            preview.style.right = 'auto';
+            preview.style.transform = 'translateX(0)';
+        }
+    }, [position]);
+    
+    return (
+        <div 
+            ref={previewRef}
+            className={classnames(
+                className, 
+                styles['hover-preview-container'],
+                styles[`position-${positionVertical}`],
+                styles[`position-${positionHorizontal}`]
+            )}
+        >
+            <div className={styles['content']}>
+                <div className={styles['header']}>
+                    <div className={styles['title']}>{name}</div>
+                    {rating && (
+                        <div className={styles['rating']}>
+                            <Icon className={styles['star-icon']} name={'star'} />
+                            <div className={styles['rating-value']}>{rating}</div>
+                        </div>
+                    )}
+                </div>
+                
+                <div className={styles['meta-info']}>
+                    {type && <span className={styles['type']}>{t(type.toUpperCase())}</span>}
+                    {releaseInfo && <span className={styles['release-info']}>{releaseInfo}</span>}
+                    {runtime && <span className={styles['runtime']}>{runtime}</span>}
+                </div>
+                
+                {genres && genres.length > 0 && (
+                    <div className={styles['genres']}>
+                        {genres.map((genre, index) => (
+                            <span key={index} className={styles['genre']}>{genre}</span>
+                        ))}
+                    </div>
+                )}
+                
+                {description && (
+                    <div className={styles['description']}>
+                        {description.length > 150 ? `${description.substring(0, 150)}...` : description}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+HoverPreview.propTypes = {
+    className: PropTypes.string,
+    name: PropTypes.string,
+    type: PropTypes.string,
+    releaseInfo: PropTypes.string,
+    runtime: PropTypes.string,
+    description: PropTypes.string,
+    genres: PropTypes.arrayOf(PropTypes.string),
+    rating: PropTypes.string,
+    position: PropTypes.string // Format: 'top-center', 'bottom-left', etc.
+};
+
+module.exports = HoverPreview;

--- a/src/components/HoverPreview/index.js
+++ b/src/components/HoverPreview/index.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2017-2025 Smart code 203358507
+
+const HoverPreview = require('./HoverPreview');
+
+module.exports = HoverPreview;

--- a/src/components/HoverPreview/styles.less
+++ b/src/components/HoverPreview/styles.less
@@ -1,0 +1,182 @@
+// Copyright (C) 2017-2025 Smart code 203358507
+
+@import (reference) '~@stremio/stremio-colors/less/stremio-colors.less';
+@import (reference) '~stremio/common/screen-sizes.less';
+
+.hover-preview-container {
+    position: absolute;
+    z-index: 100;
+    width: 22rem;
+    max-width: 90vw;
+    background-color: var(--primary-background-color);
+    border-radius: var(--border-radius);
+    box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    pointer-events: none;
+    
+    // Default position (above the card)
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-bottom: 1rem;
+    
+    // Make sure the preview stays within viewport
+    max-height: calc(80vh - 2rem);
+    overflow-y: auto;
+    
+    &.position-top {
+        bottom: 100%;
+        top: auto;
+        margin-bottom: 1rem;
+        margin-top: 0;
+        
+        &::after {
+            top: 100%;
+            bottom: auto;
+            border-color: var(--primary-background-color) transparent transparent transparent;
+        }
+    }
+    
+    &.position-bottom {
+        top: 100%;
+        bottom: auto;
+        margin-top: 1rem;
+        margin-bottom: 0;
+        
+        &::after {
+            bottom: 100%;
+            top: auto;
+            border-color: transparent transparent var(--primary-background-color) transparent;
+        }
+    }
+    
+    &.position-left {
+        left: 0;
+        transform: translateX(0);
+        
+        &::after {
+            left: 2rem;
+            transform: translateX(0);
+        }
+        
+        &.position-top::after,
+        &.position-bottom::after {
+            left: 2rem;
+        }
+    }
+    
+    &.position-right {
+        left: auto;
+        right: 0;
+        transform: translateX(0);
+        
+        &::after {
+            left: auto;
+            right: 2rem;
+            transform: translateX(0);
+        }
+        
+        &.position-top::after,
+        &.position-bottom::after {
+            right: 2rem;
+            left: auto;
+        }
+    }
+    
+    &.position-center {
+        left: 50%;
+        transform: translateX(-50%);
+        
+        &::after {
+            left: 50%;
+            transform: translateX(-50%);
+        }
+    }
+    
+    &::after {
+        content: '';
+        position: absolute;
+        border-width: 0.6rem;
+        border-style: solid;
+    }
+    
+    .content {
+        padding: 1.2rem;
+        
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 0.6rem;
+            
+            .title {
+                font-size: 1.1rem;
+                font-weight: 600;
+                color: var(--primary-foreground-color);
+                margin-right: 1rem;
+                flex: 1;
+            }
+            
+            .rating {
+                display: flex;
+                align-items: center;
+                
+                .star-icon {
+                    color: var(--primary-accent-color);
+                    width: 1rem;
+                    height: 1rem;
+                    margin-right: 0.3rem;
+                }
+                
+                .rating-value {
+                    color: var(--primary-foreground-color);
+                    font-weight: 600;
+                    font-size: 0.9rem;
+                }
+            }
+        }
+        
+        .meta-info {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.8rem;
+            margin-bottom: 0.8rem;
+            
+            .type, .release-info, .runtime {
+                font-size: 0.85rem;
+                color: var(--primary-foreground-color);
+                opacity: 0.7;
+            }
+            
+            .type {
+                text-transform: capitalize;
+            }
+        }
+        
+        .genres {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-bottom: 0.8rem;
+            
+            .genre {
+                font-size: 0.8rem;
+                background-color: var(--overlay-color);
+                color: var(--primary-foreground-color);
+                padding: 0.2rem 0.5rem;
+                border-radius: 1rem;
+            }
+        }
+        
+        .description {
+            font-size: 0.85rem;
+            line-height: 1.4;
+            color: var(--primary-foreground-color);
+            opacity: 0.8;
+            max-height: 7rem;
+            overflow: hidden;
+        }
+    }
+}

--- a/src/components/MetaItem/MetaItem.js
+++ b/src/components/MetaItem/MetaItem.js
@@ -9,13 +9,74 @@ const { default: Icon } = require('@stremio/stremio-icons/react');
 const { default: Button } = require('stremio/components/Button');
 const { default: Image } = require('stremio/components/Image');
 const Multiselect = require('stremio/components/Multiselect');
+const HoverPreview = require('stremio/components/HoverPreview');
 const useBinaryState = require('stremio/common/useBinaryState');
 const { ICON_FOR_TYPE } = require('stremio/common/CONSTANTS');
 const styles = require('./styles');
 
-const MetaItem = React.memo(({ className, type, name, poster, posterShape, posterChangeCursor, progress, newVideos, options, deepLinks, dataset, optionOnSelect, onDismissClick, onPlayClick, watched, ...props }) => {
+const MetaItem = React.memo(({ className, type, name, poster, posterShape, posterChangeCursor, progress, newVideos, options, deepLinks, dataset, optionOnSelect, onDismissClick, onPlayClick, watched, releaseInfo, runtime, description, genres, rating, ...props }) => {
     const { t } = useTranslation();
     const [menuOpen, onMenuOpen, onMenuClose] = useBinaryState(false);
+    const [isHovered, setIsHovered] = React.useState(false);
+    const [previewPosition, setPreviewPosition] = React.useState('top-center');
+    const itemRef = React.useRef(null);
+    
+    const calculatePosition = React.useCallback(() => {
+        if (!itemRef.current) return 'top-center';
+        
+        const rect = itemRef.current.getBoundingClientRect();
+        const viewportHeight = window.innerHeight;
+        const viewportWidth = window.innerWidth;
+        
+        // Get the preview width (from CSS or use an approximation)
+        const previewWidth = 22 * 16; // 22rem in pixels (assuming 1rem = 16px)
+        const previewHeight = 200; // Approximate height in pixels
+        
+        // Calculate vertical position (top or bottom)
+        // For items near the top of the screen, show preview below
+        // For items near the bottom of the screen, show preview above
+        const verticalPos = rect.top < previewHeight + 50 || rect.top < viewportHeight * 0.3 ? 'bottom' : 'top';
+        
+        // Calculate horizontal position (left, center, or right)
+        let horizontalPos = 'center';
+        
+        // If item is near the left edge, align preview to the left
+        if (rect.left < previewWidth / 2 + 20) {
+            horizontalPos = 'left';
+        } 
+        // If item is near the right edge, align preview to the right
+        else if (viewportWidth - rect.right < previewWidth / 2 + 20) {
+            horizontalPos = 'right';
+        }
+        
+        return `${verticalPos}-${horizontalPos}`;
+    }, []);
+    
+    const handleMouseEnter = React.useCallback(() => {
+        const position = calculatePosition();
+        setPreviewPosition(position);
+        setIsHovered(true);
+    }, [calculatePosition]);
+    
+    const handleMouseLeave = React.useCallback(() => {
+        setIsHovered(false);
+    }, []);
+    
+    // Recalculate position on window resize
+    React.useEffect(() => {
+        if (!isHovered) return;
+        
+        const handleResize = () => {
+            const position = calculatePosition();
+            setPreviewPosition(position);
+        };
+        
+        window.addEventListener('resize', handleResize);
+        return () => {
+            window.removeEventListener('resize', handleResize);
+        };
+    }, [isHovered, calculatePosition]);
+    
     const href = React.useMemo(() => {
         return deepLinks ?
             typeof deepLinks.player === 'string' ?
@@ -62,7 +123,36 @@ const MetaItem = React.memo(({ className, type, name, poster, posterShape, poste
         <Icon className={styles['icon']} name={'more-vertical'} />
     ), []);
     return (
-        <Button title={name} href={href} {...filterInvalidDOMProps(props)} className={classnames(className, styles['meta-item-container'], styles['poster-shape-poster'], styles[`poster-shape-${posterShape}`], { 'active': menuOpen })} onClick={metaItemOnClick}>
+        <Button 
+            title={name} 
+            href={href} 
+            ref={itemRef}
+            {...filterInvalidDOMProps(props)} 
+            className={classnames(
+                className, 
+                styles['meta-item-container'], 
+                styles['poster-shape-poster'], 
+                styles[`poster-shape-${posterShape}`], 
+                { 'active': menuOpen },
+                { [styles['is-hovered']]: isHovered }
+            )} 
+            onClick={metaItemOnClick} 
+            onMouseEnter={handleMouseEnter} 
+            onMouseLeave={handleMouseLeave}
+        >
+            {isHovered && name && (
+                <HoverPreview
+                    className={styles['hover-preview']}
+                    name={name}
+                    type={type}
+                    releaseInfo={releaseInfo}
+                    runtime={runtime}
+                    description={description}
+                    genres={genres}
+                    rating={rating}
+                    position={previewPosition}
+                />
+            )}
             <div className={classnames(styles['poster-container'], { 'poster-change-cursor': posterChangeCursor })}>
                 {
                     onDismissClick ?
@@ -175,7 +265,13 @@ MetaItem.propTypes = {
     onDismissClick: PropTypes.func,
     onPlayClick: PropTypes.func,
     onClick: PropTypes.func,
-    watched: PropTypes.bool
+    watched: PropTypes.bool,
+    // New props for hover preview
+    releaseInfo: PropTypes.string,
+    runtime: PropTypes.string,
+    description: PropTypes.string,
+    genres: PropTypes.arrayOf(PropTypes.string),
+    rating: PropTypes.string
 };
 
 module.exports = MetaItem;

--- a/src/components/MetaItem/MetaItemEnhancer.js
+++ b/src/components/MetaItem/MetaItemEnhancer.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2017-2025 Smart code 203358507
+
+const React = require('react');
+const PropTypes = require('prop-types');
+const CONSTANTS = require('stremio/common/CONSTANTS');
+
+// Helper function to create a console logger to see what data is available
+// but only in dev mode to avoid logging in production
+const debugLog = (data) => {
+    if (process.env.NODE_ENV !== 'production') {
+        console.log('MetaItem debug:', data);
+    }
+};
+
+// Helper function to extract genres from links array
+const extractGenres = (links) => {
+    if (!Array.isArray(links)) {
+        return null;
+    }
+    
+    // Look for links with category 'genre' or similar
+    const genreLinks = links.filter(link => 
+        link && typeof link.category === 'string' && 
+        (link.category.toLowerCase() === 'genre' || link.category.toLowerCase() === 'genres')
+    );
+    
+    if (genreLinks.length === 0) {
+        return null;
+    }
+    
+    return genreLinks.map(link => link.name);
+};
+
+// Helper function to extract IMDb rating from links
+const extractImdbRating = (links) => {
+    if (!Array.isArray(links)) {
+        return null;
+    }
+    
+    const imdbLink = links.find(link => 
+        link && link.category === CONSTANTS.IMDB_LINK_CATEGORY && typeof link.name === 'string'
+    );
+    
+    return imdbLink ? imdbLink.name : null;
+};
+
+// Creates a MetaItemEnhancer that enhances a MetaItem with hover preview data
+const MetaItemEnhancer = {
+    enhance: (metaItem) => {
+        // Debug the first item once to see what data is available
+        if (process.env.NODE_ENV !== 'production' && !MetaItemEnhancer._logged) {
+            debugLog(metaItem);
+            MetaItemEnhancer._logged = true;
+        }
+        
+        if (!metaItem) {
+            return metaItem;
+        }
+        
+        return {
+            ...metaItem,
+            genres: extractGenres(metaItem.links),
+            imdbRating: extractImdbRating(metaItem.links)
+        };
+    },
+    _logged: false
+};
+
+module.exports = MetaItemEnhancer;

--- a/src/components/MetaItem/styles.less
+++ b/src/components/MetaItem/styles.less
@@ -18,11 +18,25 @@
 .meta-item-container {
     padding: 1rem;
     overflow: visible;
+    position: relative;
+
+    .hover-preview {
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.2s ease, visibility 0.2s ease;
+    }
+
+    &.is-hovered {
+        .hover-preview {
+            opacity: 1;
+            visibility: visible;
+        }
+    }
 
     &:hover, &:focus, &:global(.active), &:global(.selected) {
         outline-style: none;
         transition: background-color 100ms ease-out;
-
+        
         .poster-container {
             box-shadow: 0 0 0 0.2rem var(--primary-foreground-color);
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ import ContinueWatchingItem from './ContinueWatchingItem';
 import DelayedRenderer from './DelayedRenderer';
 import EventModal from './EventModal';
 import HorizontalScroll from './HorizontalScroll';
+import HoverPreview from './HoverPreview';
 import Image from './Image';
 import LibItem from './LibItem';
 import MainNavBars from './MainNavBars';
@@ -42,6 +43,7 @@ export {
     DelayedRenderer,
     EventModal,
     HorizontalScroll,
+    HoverPreview,
     Image,
     LibItem,
     MainNavBars,

--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -157,21 +157,38 @@ const Discover = ({ urlParams, queryParams }) => {
                                     </div>
                                     :
                                     <div ref={metasContainerRef} className={classnames(styles['meta-items-container'], 'animation-fade-in')} onScroll={onScroll} onFocusCapture={metaItemsOnFocusCapture}>
-                                        {discover.catalog.content.content.map((metaItem, index) => (
-                                            <MetaItem
-                                                key={index}
-                                                className={classnames({ 'selected': selectedMetaItemIndex === index })}
-                                                type={metaItem.type}
-                                                name={metaItem.name}
-                                                poster={metaItem.poster}
-                                                posterShape={metaItem.posterShape}
-                                                playname={selectedMetaItemIndex === index}
-                                                deepLinks={metaItem.deepLinks}
-                                                watched={metaItem.watched}
-                                                data-index={index}
-                                                onClick={metaItemOnClick}
-                                            />
-                                        ))}
+                                        {discover.catalog.content.content.map((metaItem, index) => {
+                                            // Extract genres from links if available
+                                            const genres = metaItem.links ? metaItem.links
+                                                .filter(link => link && typeof link.category === 'string' && 
+                                                    (link.category.toLowerCase() === 'genre' || link.category.toLowerCase() === 'genres'))
+                                                .map(link => link.name) : null;
+                                                
+                                            // Extract IMDb rating if available
+                                            const imdbRating = metaItem.links ? metaItem.links
+                                                .find(link => link && link.category === CONSTANTS.IMDB_LINK_CATEGORY && typeof link.name === 'string')?.name : null;
+                                            
+                                            return (
+                                                <MetaItem
+                                                    key={index}
+                                                    className={classnames({ 'selected': selectedMetaItemIndex === index })}
+                                                    type={metaItem.type}
+                                                    name={metaItem.name}
+                                                    poster={metaItem.poster}
+                                                    posterShape={metaItem.posterShape}
+                                                    playname={selectedMetaItemIndex === index}
+                                                    deepLinks={metaItem.deepLinks}
+                                                    watched={metaItem.watched}
+                                                    releaseInfo={metaItem.releaseInfo}
+                                                    runtime={metaItem.runtime}
+                                                    description={metaItem.description}
+                                                    genres={genres}
+                                                    rating={imdbRating}
+                                                    data-index={index}
+                                                    onClick={metaItemOnClick}
+                                                />
+                                            );
+                                        })}
                                     </div>
                     }
                 </div>


### PR DESCRIPTION
## Features
- Adds hover preview for MetaItem components showing title, type, release info, runtime, genres, rating, and description
- Implements smart positioning to prevent previews from being cut off at screen edges
- Dynamically adjusts preview position based on card's location in the viewport
- Handles responsive layout with window resize events
- Provides visual feedback with smooth transitions

## Implementation Details
- Created new HoverPreview component with CSS positioning system
- Enhanced MetaItem to calculate optimal preview position
- Added responsive behavior to ensure previews remain visible within viewport
- Used React's useRef and useState hooks to track positions and hover state
- Ensured proper arrow positioning for all preview positions

## Testing
Tested across various screen sizes and with cards positioned in different parts of the viewport, including edges and corners.

## Screenshots
<img width="1920" height="928" alt="Screenshot (6)" src="https://github.com/user-attachments/assets/5a8d414e-8d68-4a31-a2a4-d36faa55eba8" />
<hr>
<img width="1920" height="928" alt="Screenshot (7)" src="https://github.com/user-attachments/assets/07c68c46-50d8-4f72-934c-59b88961a54c" />
