### PR TITLE
docs: Add instructions for running with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ npm start
 npm run build
 ```
 
+### Run with Docker
+
+```bash
+docker build -t stremio-web .
+docker run -p 8080:8080 stremio-web
+```
+
 ## Screenshots
 
 ### Board


### PR DESCRIPTION
This pull request adds a "Run with Docker" section to the `README.md` file. The current documentation provides instructions for local development using `pnpm` but lacks guidance for running the project with Docker.

Closes: https://github.com/Stremio/stremio-web/issues/1021

### Problem

- No documented instructions for building or running the project via Docker.
- Unclear how to expose ports or provide necessary configurations.

### Solution

- Added a "Run with Docker" section to the `README.md`.
- Included example commands for building and running the Docker image:
  - `docker build -t stremio-web .`
  - `docker run -p 8080:8080 stremio-web`
  
### Code of Conduct
- [x] I agree

