### PR TITLE
docs: add Docker instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ pnpm start
 pnpm run build
 ```
 
+### Run with Docker
+
+Build the image:
+
+```bash
+docker build -t stremio-web .
+```
+
+Run the container:
+
+```bash
+docker run --rm -p 8080:8080 stremio-web
+```
+
+Open `http://localhost:8080` in your browser.
+
 ## Screenshots
 
 ### Board


### PR DESCRIPTION
### Related

Closes #1021


### Summary
Add a “Run with Docker” section to the README, showing how to build and run the app in a container and where to access it locally.

### Motivation

- Make it easy for contributors and users to try the app without installing Node/pnpm locally.
- Provide a consistent, reproducible environment for running the app.

### Changes

- README: Added “Run with Docker” section after “Production build” including:

```sh
docker build -t stremio-web .
docker run --rm -p 8080:8080 stremio-web
# Access URL: http://localhost:8080
```
