### PR TITLE
feat: add DISABLE_SERVICE_WORKER build/runtime toggle (fixes #986)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ pnpm start
 pnpm run build
 ```
 
+### Disable service worker
+
+When deploying behind authentication middlewares (or for testing) you may want to
+disable the generated service worker so the root page isn't served from cache.
+
+Set the `DISABLE_SERVICE_WORKER` environment variable to `1` (or `true`) at
+build-time to prevent the service worker from being generated. Additionally,
+at runtime the same variable prevents the client from registering a service
+worker if present.
+
+Example (build without SW):
+
+```bash
+DISABLE_SERVICE_WORKER=1 pnpm run build
+```
+
+Example (start production server without registering SW):
+
+```bash
+DISABLE_SERVICE_WORKER=1 pnpm start-prod
+```
+
 ## Screenshots
 
 ### Board

--- a/src/index.js
+++ b/src/index.js
@@ -36,11 +36,19 @@ i18n
 const root = ReactDOM.createRoot(document.getElementById('app'));
 root.render(<App />);
 
-if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+// Register service worker in production unless explicitly disabled via
+// the DISABLE_SERVICE_WORKER environment variable. Use value '1' or 'true'
+// to disable at runtime (useful when behind auth middlewares that must run
+// on the network first).
+if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator && !(process.env.DISABLE_SERVICE_WORKER === '1' || process.env.DISABLE_SERVICE_WORKER === 'true')) {
     window.addEventListener('load', () => {
         navigator.serviceWorker.register('service-worker.js')
             .catch((registrationError) => {
                 console.error('SW registration failed: ', registrationError);
             });
     });
+} else if (process.env.NODE_ENV === 'production' && (process.env.DISABLE_SERVICE_WORKER === '1' || process.env.DISABLE_SERVICE_WORKER === 'true')) {
+    // Helpful debug log when disabled in production
+    // eslint-disable-next-line no-console
+    console.info('Service worker registration skipped because DISABLE_SERVICE_WORKER is set.');
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -223,7 +223,11 @@ module.exports = (env, argv) => ({
         new CleanWebpackPlugin({
             cleanOnceBeforeBuildPatterns: ['*']
         }),
-        argv.mode === 'production' &&
+        // Only generate a service worker in production builds when the
+        // DISABLE_SERVICE_WORKER env var is not set. This allows deploying
+        // Stremio behind authentication middlewares without the root page
+        // being cached by a SW.
+        argv.mode === 'production' && !env.DISABLE_SERVICE_WORKER &&
             new WorkboxPlugin.GenerateSW({
                 maximumFileSizeToCacheInBytes: 20000000,
                 clientsClaim: true,


### PR DESCRIPTION
## feat: add DISABLE_SERVICE_WORKER toggle (fixes #986)

Add build-time and runtime opt-out for the service worker.

Files changed:
- `webpack.config.js` (skip Workbox when `DISABLE_SERVICE_WORKER` set)
- `src/index.js` (skip SW registration when `DISABLE_SERVICE_WORKER` set)
- `README.md` (docs)

Quick test:
- Build without SW: `DISABLE_SERVICE_WORKER=1 pnpm run build`
- Run tests: `pnpm test`

Fixes #986