### PR TITLE
Misc: Use correct args for PullUserFromAPI method

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -159,7 +159,8 @@ const App = () => {
             services.core.transport.dispatch({
                 action: 'Ctx',
                 args: {
-                    action: 'PullUserFromAPI'
+                    action: 'PullUserFromAPI',
+                    args: {}
                 }
             });
             services.core.transport.dispatch({


### PR DESCRIPTION
because of recent core changes we can't skip `args` even when empty