### PR TITLE
MetaPreview: hide ActionButton label on mobile

### DIFF
--- a/src/components/MetaPreview/ActionButton/styles.less
+++ b/src/components/MetaPreview/ActionButton/styles.less
@@ -66,6 +66,15 @@
 
         .icon-container {
             width: 2rem;
+
+            .icon {
+                width: 2rem;
+                height: 2rem;
+            }
+        }
+
+        .label-container {
+            display: none;
         }
     }
 }


### PR DESCRIPTION
icon sizing changes are to match the container size, imo it looks better this way