### PR TITLE
Calendar: Poster visibility improvements

### DIFF
--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -27,11 +27,11 @@
     }
 
     .heading {
-    position: relative;
-    height: 100%;
-    display: flex;
-    align-items: start;
-    padding: 0;
+        position: relative;
+        height: 100%;
+        display: flex;
+        align-items: start;
+        padding: 0;
 
         .day {
             flex: none;

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -63,7 +63,6 @@
             height: 100%;
             aspect-ratio: 2 / 3;
             border-radius: var(--border-radius);
-            aspect-ratio: 2 / 3;
             height: 100%;
             max-height: clamp(8rem, 25vh, 14rem);
 

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -28,7 +28,7 @@
 
     .heading {
         position: relative;
-        width: 60%;
+        width: 100%;
         display: flex;
         align-items: start;
         padding: 0;
@@ -52,7 +52,7 @@
         position: relative;
         display: flex;
         flex-direction: row;
-        gap: 1rem;
+        gap: 0.1em;
         padding: 0.1rem;
         width: 90%;
 
@@ -80,13 +80,10 @@
             }
 
             .poster {
-                flex: auto;
-                z-index: 0;
-                position: relative;
-                height: 100%;
-                width: 100%;
+                height: auto;
+                max-height: 100%;
+                aspect-ratio: 2 / 3;
                 object-fit: cover;
-                opacity: 1;
             }
 
             .icon, .poster {
@@ -134,27 +131,19 @@
     }
 }
 
-@media only screen and (orientation: portrait) {
+@media @phone-portrait {
     .cell {
         flex-direction: column;
         display: grid;
-        .heading {
-            justify-content: center;
-        }
 
         .items {
-          padding: 1px;
-          gap: 0.15rem;
-          justify-content: space-evenly;
+            padding: 1px;
+            gap: 0.15rem;
+            justify-content: space-evenly;
 
-          .item{
-            width: 80%;
-          }
-        }
-
-        .more {
-            display: flex;
-            display: none;
+            .item {
+                width: 80%;
+            }
         }
     }
 }
@@ -180,4 +169,36 @@
             }
         }
     }
+}
+
+@media only screen and (max-width: @minimum) and (orientation: portrait) and (pointer: fine) {
+  .cell {
+      position: relative;
+      flex-direction: row;
+      align-items: center;
+      display: flex;
+
+      .items {
+          display: none;
+      }
+
+      .heading {
+          display: flex;
+          align-items: center;
+          gap: 0.25rem;
+          width: auto; 
+      }
+
+      .day {
+          margin-right: 0.25rem;
+      }
+
+      .more {
+          display: inline-flex;
+          position: relative;
+          height: auto;
+          padding: 0;
+          width: 30%;
+      }
+  }
 }

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -51,7 +51,7 @@
         position: relative;
         display: flex;
         flex-direction: row;
-        gap: 0.1em;
+        gap: 0.2rem;
         padding: 0.1rem;
         flex: 1 1 60%;
         overflow-x: auto;
@@ -67,7 +67,7 @@
             aspect-ratio: 2 / 3;
             border-radius: calc(var(--border-radius) /2);
             max-height: 100%;
-            width: 100%;
+            max-width: 100%;
 
             .icon {
                 flex: none;

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -167,12 +167,19 @@
     }
 }
 
-@media only screen and (max-height: @xxsmall) and (max-width: @xxsmall) and (orientation: landscape) {
-  .cell{
-    .items{
-        width: 100%;
+@media @phone-landscape {
+    .cell {
+        flex-direction: row;
+
+        .items {
+            padding: 1px;
+            gap: 0.15rem;
+
+            .item {
+                pointer-events: none;
+            }
+        }
     }
-  }
 }
 
 

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -27,12 +27,11 @@
     }
 
     .heading {
-        flex: none;
         position: relative;
-        height: 3rem;
+    height: 100%;
         display: flex;
-        align-items: center;
-        padding: 0 1rem;
+    align-items: start;
+    padding: 0;
 
         .day {
             flex: none;
@@ -50,7 +49,6 @@
     }
 
     .items {
-        flex: 0 1 10rem;
         position: relative;
         display: flex;
         flex-direction: row;
@@ -65,6 +63,9 @@
             height: 100%;
             aspect-ratio: 2 / 3;
             border-radius: var(--border-radius);
+      aspect-ratio: 2 / 3;
+      height: 100%;
+      max-height: clamp(8rem, 25vh, 14rem);
 
             .icon {
                 flex: none;
@@ -150,28 +151,33 @@
     }
 }
 
-@media only screen and (max-height: @xxsmall) and (orientation: landscape) {
+@media only screen and (max-height: @xsmall) and (max-width: @xsmall) {
     .cell {
-        flex-direction: row;
-        align-items: center;
+    gap: 0;
+
+    .heading {
+      .day {
+        font-size: 0.875rem;
+      }
+    }
 
         .items {
+      padding: 0.25rem;
             display: none;
-        }
 
-        .more {
-            display: flex;
+      .item {
+        pointer-events: none;
+        border-radius: calc(var(--border-radius) / 2);
+      }
         }
     }
 }
 
-@media only screen and (max-height: @xsmall) and (max-width: @xsmall) {
+@media only screen and (max-height: @small) and (max-width: @small) {
     .cell {
         gap: 0;
 
         .heading {
-            height: 2rem;
-
             .day {
                 font-size: 0.875rem;
             }
@@ -179,6 +185,8 @@
 
         .items {
             padding: 0.25rem;
+      width: 100%;
+      height: 100%;
 
             .item {
                 pointer-events: none;

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -29,7 +29,7 @@
     .heading {
         position: relative;
         display: flex;
-        align-items: center;
+        align-items: flex-start;
 
         .day {
             flex: none;
@@ -165,7 +165,7 @@
 
 @media @phone-landscape {
     .cell {
-        flex-direction: column;
+        flex-direction: row;
 
         .items {
             padding: 1px;
@@ -182,7 +182,6 @@
 @media only screen and (max-height: @medium) and (max-width: @medium) and (orientation: landscape) {
     .cell {
         gap: 0;
-        flex-direction: column;
 
         .heading {
             .day {

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -27,9 +27,9 @@
     }
 
     .heading {
-        position: relative;
+    position: relative;
     height: 100%;
-        display: flex;
+    display: flex;
     align-items: start;
     padding: 0;
 
@@ -63,9 +63,9 @@
             height: 100%;
             aspect-ratio: 2 / 3;
             border-radius: var(--border-radius);
-      aspect-ratio: 2 / 3;
-      height: 100%;
-      max-height: clamp(8rem, 25vh, 14rem);
+            aspect-ratio: 2 / 3;
+            height: 100%;
+            max-height: clamp(8rem, 25vh, 14rem);
 
             .icon {
                 flex: none;
@@ -153,22 +153,22 @@
 
 @media only screen and (max-height: @xsmall) and (max-width: @xsmall) {
     .cell {
-    gap: 0;
+        gap: 0;
 
-    .heading {
-      .day {
-        font-size: 0.875rem;
-      }
-    }
+        .heading {
+          .day {
+            font-size: 0.875rem;
+          }
+        }
 
         .items {
-      padding: 0.25rem;
+            padding: 0.25rem;
             display: none;
 
-      .item {
-        pointer-events: none;
-        border-radius: calc(var(--border-radius) / 2);
-      }
+        .item {
+          pointer-events: none;
+          border-radius: calc(var(--border-radius) / 2);
+        }
         }
     }
 }
@@ -185,8 +185,8 @@
 
         .items {
             padding: 0.25rem;
-      width: 100%;
-      height: 100%;
+            width: 100%;
+            height: 100%;
 
             .item {
                 pointer-events: none;

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -208,7 +208,3 @@
 @media screen and (max-width: @small) and (orientation: portrait) {
     .disable-cell-items();
 }
-
-@media screen and (min-width: @small-phone-portrait-size) and (max-width: @small) and (orientation: portrait) {
-    .disable-cell-items();
-}

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -5,7 +5,7 @@
 .cell {
     position: relative;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     justify-content: space-between;
     gap: 0.5rem;
     background-color: var(--overlay-color);
@@ -28,9 +28,8 @@
 
     .heading {
         position: relative;
-        flex: 1 1 40%;
         display: flex;
-        align-items: flex-start;
+        align-items: center;
 
         .day {
             flex: none;
@@ -65,7 +64,7 @@
             justify-content: center;
             height: 100%;
             aspect-ratio: 2 / 3;
-            border-radius: calc(var(--border-radius) /2);
+            border-radius: calc(var(--border-radius) / 2);
             max-height: 100%;
             max-width: 100%;
 
@@ -118,11 +117,11 @@
 
     &.today {
         .heading {
+            padding: 0.3rem;
             .day {
-                width: auto;
                 background-color: var(--primary-accent-color);
-                height: auto;
-                padding: 0.3rem;
+                height: 1.5rem;
+                width: 1.5rem;
             }
         }
     }
@@ -138,15 +137,14 @@
     }
 }
 
-@media only screen and (max-width: @minimum) and (orientation: portrait) {
-  .cell{
-    .items{
-        .item{
-            pointer-events: none;
+@media only screen and (max-width: @minimum) {
+    .cell {
+        .items {
+            .item {
+                pointer-events: none;
+            }
         }
-
     }
-  }
 }
 
 @media @phone-portrait {
@@ -157,10 +155,8 @@
         .items {
             padding: 1px;
             gap: 0.15rem;
-            justify-content: space-evenly;
 
             .item {
-                width: 100%;
                 pointer-events: none;
             }
         }
@@ -169,7 +165,7 @@
 
 @media @phone-landscape {
     .cell {
-        flex-direction: row;
+        flex-direction: column;
 
         .items {
             padding: 1px;
@@ -186,10 +182,11 @@
 @media only screen and (max-height: @medium) and (max-width: @medium) and (orientation: landscape) {
     .cell {
         gap: 0;
-        flex-direction: row;
+        flex-direction: column;
 
         .heading {
             .day {
+                padding: 0;
                 font-size: 0.875rem;
             }
         }
@@ -201,25 +198,11 @@
 }
 
 @media only screen and (max-width: @minimum) and (orientation: portrait) and (pointer: fine) {
-  .cell {
-      position: relative;
-      flex-direction: row;
-      display: flex;
+    .cell {
+        display: flex;
 
-      .items{
-          .item{
-              pointer-events: none;
-          }
-      }
-
-      .heading {
-          display: flex;
-          gap: 0.25rem;
-          width: auto; 
-          .day{
-              font-size: 0.6rem;
-          }
-
-      }
-  }
+        .heading {
+            flex: 1 1 33%;
+        }
+    }
 }

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -28,10 +28,9 @@
 
     .heading {
         position: relative;
-        width: 100%;
+        flex: 1 1 40%;
         display: flex;
-        align-items: start;
-        padding: 0;
+        align-items: flex-start;
 
         .day {
             flex: none;
@@ -54,7 +53,10 @@
         flex-direction: row;
         gap: 0.1em;
         padding: 0.1rem;
-        width: 90%;
+        flex: 1 1 60%;
+        overflow-x: auto;
+        overflow-y: hidden; 
+        min-width: 0;
 
         .item {
             flex: none;
@@ -63,8 +65,9 @@
             justify-content: center;
             height: 100%;
             aspect-ratio: 2 / 3;
-            border-radius: var(--border-radius);
-            max-height: clamp(8rem, 25vh, 14rem);
+            border-radius: calc(var(--border-radius) /2);
+            max-height: 100%;
+            width: 100%;
 
             .icon {
                 flex: none;
@@ -84,6 +87,7 @@
                 max-height: 100%;
                 aspect-ratio: 2 / 3;
                 object-fit: cover;
+                border-radius: inherit
             }
 
             .icon, .poster {
@@ -115,7 +119,10 @@
     &.today {
         .heading {
             .day {
+                width: auto;
                 background-color: var(--primary-accent-color);
+                height: auto;
+                padding: 0.3rem;
             }
         }
     }
@@ -142,11 +149,20 @@
             justify-content: space-evenly;
 
             .item {
-                width: 80%;
+                width: 100%;
             }
         }
     }
 }
+
+@media only screen and (max-height: @xxsmall) and (max-width: @xxsmall) and (orientation: landscape) {
+  .cell{
+    .items{
+        width: 100%;
+    }
+  }
+}
+
 
 @media only screen and (max-height: @medium) and (max-width: @medium) and (orientation: landscape) {
     .cell {
@@ -161,12 +177,6 @@
 
         .items {
             width: 100%;
-
-            .item {
-                pointer-events: none;
-                border-radius: calc(var(--border-radius) / 2);
-                width: 80%;
-            }
         }
     }
 }
@@ -175,30 +185,16 @@
   .cell {
       position: relative;
       flex-direction: row;
-      align-items: center;
       display: flex;
-
-      .items {
-          display: none;
-      }
 
       .heading {
           display: flex;
-          align-items: center;
           gap: 0.25rem;
           width: auto; 
-      }
+          .day{
+              font-size: 0.6rem;
+          }
 
-      .day {
-          margin-right: 0.25rem;
-      }
-
-      .more {
-          display: inline-flex;
-          position: relative;
-          height: auto;
-          padding: 0;
-          width: 30%;
       }
   }
 }

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -5,7 +5,7 @@
 .cell {
     position: relative;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     justify-content: space-between;
     gap: 0.5rem;
     background-color: var(--overlay-color);
@@ -28,7 +28,7 @@
 
     .heading {
         position: relative;
-        height: 100%;
+        width: 60%;
         display: flex;
         align-items: start;
         padding: 0;
@@ -53,7 +53,8 @@
         display: flex;
         flex-direction: row;
         gap: 1rem;
-        padding: 0 0.5rem 0.5rem 0.5rem;
+        padding: 0.1rem;
+        width: 90%;
 
         .item {
             flex: none;
@@ -63,7 +64,6 @@
             height: 100%;
             aspect-ratio: 2 / 3;
             border-radius: var(--border-radius);
-            height: 100%;
             max-height: clamp(8rem, 25vh, 14rem);
 
             .icon {
@@ -134,47 +134,35 @@
     }
 }
 
-@media only screen and (max-height: @minimum) and (orientation: portrait) {
+@media only screen and (orientation: portrait) {
     .cell {
+        flex-direction: column;
+        display: grid;
         .heading {
             justify-content: center;
         }
 
         .items {
-            display: none;
+          padding: 1px;
+          gap: 0.15rem;
+          justify-content: space-evenly;
+
+          .item{
+            width: 80%;
+          }
         }
 
         .more {
             display: flex;
-        }
-    }
-}
-
-@media only screen and (max-height: @xsmall) and (max-width: @xsmall) {
-    .cell {
-        gap: 0;
-
-        .heading {
-          .day {
-            font-size: 0.875rem;
-          }
-        }
-
-        .items {
-            padding: 0.25rem;
             display: none;
-
-        .item {
-          pointer-events: none;
-          border-radius: calc(var(--border-radius) / 2);
-        }
         }
     }
 }
 
-@media only screen and (max-height: @small) and (max-width: @small) {
+@media only screen and (max-height: @medium) and (max-width: @medium) and (orientation: landscape) {
     .cell {
         gap: 0;
+        flex-direction: row;
 
         .heading {
             .day {
@@ -183,13 +171,12 @@
         }
 
         .items {
-            padding: 0.25rem;
             width: 100%;
-            height: 100%;
 
             .item {
                 pointer-events: none;
                 border-radius: calc(var(--border-radius) / 2);
+                width: 80%;
             }
         }
     }

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -2,6 +2,25 @@
 
 @import (reference) '~stremio/common/screen-sizes.less';
 
+.disable-cell-items() {
+    .cell {
+        .items {
+            .item {
+                pointer-events: none;
+            }
+        }
+    }
+}
+
+.compact-items() {
+    .cell {
+        .items {
+            padding: 1px;
+            gap: 0.15rem;
+        }
+    }
+}
+
 .cell {
     position: relative;
     display: flex;
@@ -138,46 +157,25 @@
 }
 
 @media only screen and (max-width: @minimum) {
-    .cell {
-        .items {
-            .item {
-                pointer-events: none;
-            }
-        }
-    }
+    .disable-cell-items();
 }
 
 @media @phone-portrait {
     .cell {
         flex-direction: column;
         display: grid;
-
-        .items {
-            padding: 1px;
-            gap: 0.15rem;
-
-            .item {
-                pointer-events: none;
-            }
-        }
     }
+    .compact-items();
+    .disable-cell-items();
 }
 
 @media @phone-landscape {
     .cell {
         flex-direction: row;
-
-        .items {
-            padding: 1px;
-            gap: 0.15rem;
-
-            .item {
-                pointer-events: none;
-            }
-        }
     }
+    .compact-items();
+    .disable-cell-items();
 }
-
 
 @media only screen and (max-height: @medium) and (max-width: @medium) and (orientation: landscape) {
     .cell {
@@ -207,12 +205,10 @@
     }
 }
 
+@media screen and (max-width: @small) and (orientation: portrait) {
+    .disable-cell-items();
+}
+
 @media screen and (min-width: @small-phone-portrait-size) and (max-width: @small) and (orientation: portrait) {
-    .cell {
-        .items {
-            .item {
-                pointer-events: none;
-            }
-        }
-    }
+    .disable-cell-items();
 }

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -192,6 +192,7 @@
 
         .items {
             width: 100%;
+            padding-left: 0.5rem;
         }
     }
 }

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -138,6 +138,17 @@
     }
 }
 
+@media only screen and (max-width: @minimum) and (orientation: portrait) {
+  .cell{
+    .items{
+        .item{
+            pointer-events: none;
+        }
+
+    }
+  }
+}
+
 @media @phone-portrait {
     .cell {
         flex-direction: column;
@@ -150,6 +161,7 @@
 
             .item {
                 width: 100%;
+                pointer-events: none;
             }
         }
     }
@@ -186,6 +198,12 @@
       position: relative;
       flex-direction: row;
       display: flex;
+
+      .items{
+          .item{
+              pointer-events: none;
+          }
+      }
 
       .heading {
           display: flex;

--- a/src/routes/Calendar/Table/Cell/Cell.less
+++ b/src/routes/Calendar/Table/Cell/Cell.less
@@ -206,3 +206,13 @@
         }
     }
 }
+
+@media screen and (min-width: @small-phone-portrait-size) and (max-width: @small) and (orientation: portrait) {
+    .cell {
+        .items {
+            .item {
+                pointer-events: none;
+            }
+        }
+    }
+}

--- a/src/routes/Calendar/Table/Table.less
+++ b/src/routes/Calendar/Table/Table.less
@@ -45,6 +45,7 @@
         display: grid;
         grid-template-columns: repeat(7, 1fr);
         gap: 1px;
+        grid-auto-rows: 1fr;
     }
 }
 


### PR DESCRIPTION
This PR improves the calendar view by fixing poster scaling and preventing items from collapsing or disappearing at certain zoom levels.

Before: (100% Zoom 1366 x 768 screen)
<img width="1363" height="627" alt="image" src="https://github.com/user-attachments/assets/eae13e83-3bf0-4d6f-9ee0-c1c55550982a" />

After: (100% Zoom 1366 x 768 screen)
<img width="1365" height="625" alt="image" src="https://github.com/user-attachments/assets/792ef212-d256-4673-a6b2-c9fd0ccbccab" />
