### PR TITLE
Fix GitHub Actions badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stremio - Freedom to Stream
 
-![Build](https://github.com/stremio/stremio-web/workflows/Build/badge.svg?branch=development)
+[![Build](https://github.com/Stremio/stremio-web/actions/workflows/build.yml/badge.svg)](https://github.com/Stremio/stremio-web/actions/workflows/build.yml)
 [![Github Page](https://img.shields.io/website?label=Page&logo=github&up_message=online&down_message=offline&url=https%3A%2F%2Fstremio.github.io%2Fstremio-web%2F)](https://stremio.github.io/stremio-web/development)
 
 Stremio is a modern media center that's a one-stop solution for your video entertainment. You discover, watch and organize video content from easy to install addons.


### PR DESCRIPTION
Summary using GitHub Copilot:

> This pull request updates the build status badge in the `README.md` to use the new GitHub Actions workflow URL and format.
> 
> - Documentation update:
>   * Updated the build status badge in `README.md` to point to the new GitHub Actions workflow and use the current badge format.