### PR TITLE
feat: add C key shortcut to toggle subtitles on/off

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -635,6 +635,28 @@ const Player = ({ urlParams, queryParams }) => {
 
                     break;
                 }
+                case 'KeyC': {
+                    if (!menusOpen && !nextVideoPopupOpen) {
+                        const internalTracks = video.state.subtitlesTracks;
+                        const externalTracks = video.state.extraSubtitlesTracks;
+                        const hasInternal = Array.isArray(internalTracks) && internalTracks.length > 0;
+                        const hasExternal = Array.isArray(externalTracks) && externalTracks.length > 0;
+                        const hasInternalActive = video.state.selectedSubtitlesTrackId !== null;
+                        const hasExternalActive = video.state.selectedExtraSubtitlesTrackId !== null;
+
+                        if (hasInternalActive || hasExternalActive) {
+                            onSubtitlesTrackSelected(null);
+                            onExtraSubtitlesTrackSelected(null);
+                        } else if (hasInternal || hasExternal) {
+                            if (hasInternal) {
+                                onSubtitlesTrackSelected(internalTracks[0].id);
+                            } else {
+                                onExtraSubtitlesTrackSelected(externalTracks[0].id);
+                            }
+                        }
+                    }
+                    break;
+                }
                 case 'KeyA': {
                     closeMenus();
                     if (Array.isArray(video.state.audioTracks) && video.state.audioTracks.length > 0) {


### PR DESCRIPTION
- Add KeyC case handler in Player keyboard event listener
- Simple on/off toggle (like YouTube's C key)
- Opens first available subtitle when off
- Closes all subtitles when on
- Only works when menus are closed
- Fixes #322