### PR TITLE
Settings: Fix incorrect tab highlighting

### DIFF
--- a/src/routes/Settings/Settings.tsx
+++ b/src/routes/Settings/Settings.tsx
@@ -41,8 +41,9 @@ const Settings = () => {
         if (container!.scrollTop + container!.clientHeight >= container!.scrollHeight - 50) {
             setSelectedSectionId(sections[sections.length - 1].id);
         } else {
+            const tolerance = 10;
             for (let i = sections.length - 1; i >= 0; i--) {
-                if (sections[i].ref.current && sections[i].ref.current!.offsetTop - container!.offsetTop <= container!.scrollTop) {
+                if (sections[i].ref.current && sections[i].ref.current!.offsetTop - container!.offsetTop - tolerance <= container!.scrollTop) {
                     setSelectedSectionId(sections[i].id);
                     break;
                 }

--- a/src/routes/Settings/Settings.tsx
+++ b/src/routes/Settings/Settings.tsx
@@ -20,7 +20,6 @@ const Settings = () => {
     const profile = useProfile();
     const platform = usePlatform();
     const streamingServer = useStreamingServer();
-    const isScrollingRef = useRef(false);
 
     const sectionsContainerRef = useRef<HTMLDivElement>(null);
     const generalSectionRef = useRef<HTMLDivElement>(null);
@@ -38,51 +37,26 @@ const Settings = () => {
     const [selectedSectionId, setSelectedSectionId] = useState(SECTIONS.GENERAL);
 
     const updateSelectedSectionId = useCallback(() => {
-        if (isScrollingRef.current) return;
-
         const container = sectionsContainerRef.current;
-        if (!container) return;
-
-        const containerRect = container.getBoundingClientRect();
-        const tolerance = 20;
-
-        if (container.scrollTop + container.clientHeight >= container.scrollHeight - 50) {
-            setSelectedSectionId(sections[sections.length - 1].id);
-        } else {
-            for (let i = sections.length - 1; i >= 0; i--) {
-                const section = sections[i].ref.current;
-                if (section) {
-                    const sectionRect = section.getBoundingClientRect();
-                    if (sectionRect.top <= containerRect.top + tolerance) {
-                        setSelectedSectionId(sections[i].id);
-                        break;
-                    }
-                }
+        for (const section of sections) {
+            const sectionContainer = section.ref.current;
+            if (sectionContainer && (sectionContainer.offsetTop + container!.offsetTop) < container!.scrollTop + 50) {
+                setSelectedSectionId(section.id);
             }
         }
-    }, [sections]);
+    }, []);
 
     const onMenuSelect = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-        const sectionId = event.currentTarget.dataset.section;
-        const section = sections.find((s) => s.id === sectionId);
+        const section = sections.find((section) => {
+            return section.id === event.currentTarget.dataset.section;
+        });
+
         const container = sectionsContainerRef.current;
-
-        if (section && section.ref.current && container) {
-            isScrollingRef.current = true;
-            setSelectedSectionId(section.id);
-
-            const top = section.ref.current.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-
-            container.scrollTo({
-                top,
-                behavior: 'smooth'
-            });
-
-            setTimeout(() => {
-                isScrollingRef.current = false;
-            }, 1000);
-        }
-    }, [sections]);
+        section && container!.scrollTo({
+            top: section.ref.current!.offsetTop - container!.offsetTop,
+            behavior: 'smooth'
+        });
+    }, []);
 
     const onContainerScroll = useCallback(throttle(() => {
         updateSelectedSectionId();


### PR DESCRIPTION
I added scroll lock so when a tab is clicked in setting, scroll spy is disabled for a second and the clicked tab is immediately marked active to prevent highlight flicker during smooth scroll. I also replaced offsetTop with getBoundingClientRect() to provide accurate viewport-relative section offsets even inside nested scrolling contexts and the active section is now determined by the section whose top edge is closest to the container top, with a 20px margin.

Fixes #1078 