### PR TITLE
[Feature] Add-ons Bundles (URL parameter distribution)

### DIFF
--- a/src/App/SearchParamsHandler.js
+++ b/src/App/SearchParamsHandler.js
@@ -63,10 +63,7 @@ const SearchParamsHandler = () => {
             const isNewUserOrGuest = !profile?.auth || profile?.auth?.user?.isNewUser === true;
 
             if (isNewUserOrGuest) {
-                // Mark this collection as processed
                 processedAddonsCollectionRef.current = addonsCollection;
-
-                // Fetch the add-ons collection from the provided URL
                 fetch(addonsCollection)
                     .then((response) => {
                         if (!response.ok) {
@@ -77,9 +74,7 @@ const SearchParamsHandler = () => {
                     .then((collectionData) => {
                         // Install each add-on from the collection
                         if (Array.isArray(collectionData)) {
-                            // For each entry, ensure that the Core with a proper `manifest` object.
-                            // If the collection contains URLs (strings) or objects with string `manifest`/`transportUrl`,
-                            // fetch the manifest JSON first and pass the parsed object to Core.
+                            // For each entry, ensuring that the Core with a proper `manifest` object.
                             const installPromises = collectionData.map((addon) => {
                                 return new Promise((resolve) => {
                                     (async () => {
@@ -116,7 +111,7 @@ const SearchParamsHandler = () => {
                                                 // addon may contain manifest as object or URL
                                                 const name = typeof addon.name === 'string' ? addon.name : null;
                                                 if (addon.manifest && typeof addon.manifest === 'object') {
-                                                    // already an object
+
                                                     doDispatch(addon.manifest, addon.transportUrl || null, name);
                                                 } else {
                                                     // manifest field might be a URL, or fallback to transportUrl/url
@@ -146,7 +141,6 @@ const SearchParamsHandler = () => {
                                 });
                             });
 
-                            // Wait for all installs (or failures) to finish before notifying the user
                             Promise.all(installPromises).then(() => {
                                 toast.show({
                                     type: 'success',

--- a/src/App/SearchParamsHandler.js
+++ b/src/App/SearchParamsHandler.js
@@ -11,6 +11,7 @@ const SearchParamsHandler = () => {
     const toast = useToast();
 
     const [searchParams, setSearchParams] = React.useState({});
+    const processedAddonsCollectionRef = React.useRef(null);
 
     const onLocationChange = () => {
         const { origin, hash, search } = window.location;
@@ -23,7 +24,7 @@ const SearchParamsHandler = () => {
     };
 
     React.useEffect(() => {
-        const { streamingServerUrl } = searchParams;
+        const { streamingServerUrl, addonsCollection } = searchParams;
 
         if (streamingServerUrl) {
             core.transport.dispatch({
@@ -48,6 +49,122 @@ const SearchParamsHandler = () => {
                 title: `Using streaming server at ${streamingServerUrl}`,
                 timeout: 4000,
             });
+        }
+
+        // Handle custom add-ons collection for new users and guests
+        // This allows distributing pre-configured add-on bundles via URL parameter
+        // Example: ?addonsCollection=https://example.com/addons.json
+        if (addonsCollection && typeof addonsCollection === 'string' && addonsCollection.length > 0) {
+            // Processing this collection only once per session
+            if (processedAddonsCollectionRef.current === addonsCollection) {
+                return;
+            }
+
+            const isNewUserOrGuest = !profile?.auth || profile?.auth?.user?.isNewUser === true;
+
+            if (isNewUserOrGuest) {
+                // Mark this collection as processed
+                processedAddonsCollectionRef.current = addonsCollection;
+
+                // Fetch the add-ons collection from the provided URL
+                fetch(addonsCollection)
+                    .then((response) => {
+                        if (!response.ok) {
+                            throw new Error(`Failed to fetch add-ons collection: ${response.statusText}`);
+                        }
+                        return response.json();
+                    })
+                    .then((collectionData) => {
+                        // Install each add-on from the collection
+                        if (Array.isArray(collectionData)) {
+                            // For each entry, ensure that the Core with a proper `manifest` object.
+                            // If the collection contains URLs (strings) or objects with string `manifest`/`transportUrl`,
+                            // fetch the manifest JSON first and pass the parsed object to Core.
+                            const installPromises = collectionData.map((addon) => {
+                                return new Promise((resolve) => {
+                                    (async () => {
+                                        try {
+                                            // Helper to dispatch InstallAddon with manifest object
+                                            const doDispatch = (manifestObj, transportUrl, name) => {
+                                                const args = {};
+                                                if (manifestObj) args.manifest = manifestObj;
+                                                if (transportUrl) args.transportUrl = transportUrl;
+                                                if (name) args.name = name;
+                                                if (Object.keys(args).length > 0) {
+                                                    core.transport.dispatch({
+                                                        action: 'Ctx',
+                                                        args: {
+                                                            action: 'InstallAddon',
+                                                            args,
+                                                        },
+                                                    });
+                                                }
+                                            };
+
+                                            if (typeof addon === 'string') {
+                                                // treat as manifest URL: fetch and parse
+                                                const manifestUrl = addon;
+                                                try {
+                                                    const res = await fetch(manifestUrl);
+                                                    if (!res.ok) throw new Error(`Failed to fetch manifest: ${res.statusText}`);
+                                                    const manifestObj = await res.json();
+                                                    doDispatch(manifestObj, manifestUrl, null);
+                                                } catch (e) {
+                                                    console.error('Failed to fetch/parse manifest for', manifestUrl, e);
+                                                }
+                                            } else if (addon && typeof addon === 'object') {
+                                                // addon may contain manifest as object or URL
+                                                const name = typeof addon.name === 'string' ? addon.name : null;
+                                                if (addon.manifest && typeof addon.manifest === 'object') {
+                                                    // already an object
+                                                    doDispatch(addon.manifest, addon.transportUrl || null, name);
+                                                } else {
+                                                    // manifest field might be a URL, or fallback to transportUrl/url
+                                                    const manifestUrl = addon.manifest || addon.transportUrl || addon.url || null;
+                                                    if (manifestUrl && typeof manifestUrl === 'string') {
+                                                        try {
+                                                            const res = await fetch(manifestUrl);
+                                                            if (!res.ok) throw new Error(`Failed to fetch manifest: ${res.statusText}`);
+                                                            const manifestObj = await res.json();
+                                                            doDispatch(manifestObj, addon.transportUrl || manifestUrl, name);
+                                                        } catch (e) {
+                                                            console.error('Failed to fetch/parse manifest for', manifestUrl, e);
+                                                        }
+                                                    } else {
+                                                        console.warn('Skipping invalid add-on entry in collection:', addon);
+                                                    }
+                                                }
+                                            } else {
+                                                console.warn('Skipping invalid add-on entry in collection:', addon);
+                                            }
+                                        } catch (e) {
+                                            console.error('Error processing add-on entry:', addon, e);
+                                        } finally {
+                                            resolve();
+                                        }
+                                    })();
+                                });
+                            });
+
+                            // Wait for all installs (or failures) to finish before notifying the user
+                            Promise.all(installPromises).then(() => {
+                                toast.show({
+                                    type: 'success',
+                                    title: `Processed ${collectionData.length} add-on entries from collection`,
+                                    timeout: 4000,
+                                });
+                            });
+                        }
+                    })
+                    .catch((error) => {
+                        console.error('Failed to load add-ons collection:', error);
+                        toast.show({
+                            type: 'error',
+                            title: 'Failed to load add-ons collection',
+                            timeout: 4000,
+                        });
+                    });
+            }
         }
     }, [searchParams]);
 


### PR DESCRIPTION
## New
- Users/guests can receive pre-configured add-on collections via URL parameter
- Syntax: ?addonsCollection=https://example.com/collection.json
- Automatically installs installable add-ons; configure-only ones are skipped (expected behaviour since API Keys)
- Includes error handling, deduplication, and user notifications
- Backwards compatible, no breaking changes
---
## Testing
- Local Testing
- Test file:  'watch-next-collection.json' hosted on local machine.
---
#### Test 1: One link.
```
[
  "https://099757617587-watch-next.baby-beamup.club/manifest.json"  
]
```


**Before:**

<img width="1915" height="1030" alt="image" src="https://github.com/user-attachments/assets/001ce7f6-b39a-420c-945b-93952cbfc7aa" />


**During:**

<img width="1926" height="1028" alt="image" src="https://github.com/user-attachments/assets/43eb80cd-b11f-4ab5-b174-fd2e20cbc012" />


**After:**

<img width="1918" height="1031" alt="image" src="https://github.com/user-attachments/assets/8a1dd857-ca47-4bc8-9069-9653cb9c99c5" />


**For Duplicate Install:**

<img width="1920" height="1029" alt="image" src="https://github.com/user-attachments/assets/9cfd169c-ffed-4f97-9d41-988e23779a5b" />


---

#### Test 2: 1 Add-on that can be installed, and another Add-on that has to be configured and then installed
```
[
  "https://099757617587-watch-next.baby-beamup.club/manifest.json",
  "https://68d69db7dc40-debrid-search.baby-beamup.club/manifest.json"
]
```


**Before:**

<img width="1918" height="1031" alt="image" src="https://github.com/user-attachments/assets/e47f4e74-b400-40eb-b1fc-679c9f986dba" />



**During:**

<img width="1920" height="1035" alt="image" src="https://github.com/user-attachments/assets/28689fb7-a46d-404d-a4da-e3241e964e8a" />


**After:**

<img width="1930" height="1038" alt="image" src="https://github.com/user-attachments/assets/28b53632-586d-4a03-a355-c5a8c9a3ffc3" />



**For Duplicate Installs:**

<img width="1920" height="1034" alt="image" src="https://github.com/user-attachments/assets/3982b039-668b-4f25-aaab-56e5ff9e7c55" />


---

The tests above were conducted on Edge. The test showed consistent results on the latest versions of Firefox and Chrome (at the time).

---
Firefox:
145.0.2 (64-bit)

Chrome:
Version 142.0.7444.176 (Official Build) (64-bit)

Edge:
Version 142.0.3595.94 (Official build) (64-bit)

---

Note: Add-ons requiring configuration (API keys, auth tokens) will be skipped during auto-installation. Users can manually configure them after opening the app.

---

Closes: #109