### PR TITLE
MetaDetails: Add missing backdrop filter to ratings

### DIFF
--- a/src/components/MetaPreview/Ratings/Ratings.less
+++ b/src/components/MetaPreview/Ratings/Ratings.less
@@ -26,6 +26,7 @@
         width: @width;
         padding: 0 1rem;
         cursor: pointer;
+        backdrop-filter: blur(5px);
 
         .icon {
             width: calc(@width / 2);

--- a/src/components/MetaPreview/Ratings/Ratings.less
+++ b/src/components/MetaPreview/Ratings/Ratings.less
@@ -17,6 +17,7 @@
     border-radius: 2rem;
     height: @height;
     width: fit-content;
+    backdrop-filter: blur(5px);
 
     .icon-container {
         display: flex;
@@ -26,7 +27,6 @@
         width: @width;
         padding: 0 1rem;
         cursor: pointer;
-        backdrop-filter: blur(5px);
 
         .icon {
             width: calc(@width / 2);


### PR DESCRIPTION
.ratings-container missing backdrop-filter: blur like other action buttons.
<img width="604" height="99" alt="圖片" src="https://github.com/user-attachments/assets/b582d75b-8e5f-47a1-b036-aa19a54c80e7" />
