### PR TITLE
feat: cross-season search for series

### DIFF
--- a/src/routes/MetaDetails/VideosList/VideosList.js
+++ b/src/routes/MetaDetails/VideosList/VideosList.js
@@ -72,6 +72,27 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
     }, [videosForSeason]);
 
     const [search, setSearch] = React.useState('');
+
+    const filteredVideos = React.useMemo(() => {
+        // When searching: use ALL videos across all seasons
+        // When browsing normally: use only videos from selected season
+        return (search.length > 0 ? videos : videosForSeason)
+            .filter((video) => {
+                return search.length === 0 ||
+                    (
+                        (typeof video.title === 'string' && video.title.toLowerCase().includes(search.toLowerCase())) ||
+                        (!isNaN(video.released.getTime()) && video.released.toLocaleString(profile.settings.interfaceLanguage, { year: '2-digit', month: 'short', day: 'numeric' }).toLowerCase().includes(search.toLowerCase()))
+                    );
+            })
+            .sort((a, b) => {
+                if (search.length > 0) {
+                    // Sort chronologically by season and episode
+                    return (a.season - b.season) || (a.episode - b.episode);
+                }
+                return 0;
+            });
+    }, [videos, videosForSeason, search, profile.settings.interfaceLanguage]);
+
     const searchInputOnChange = React.useCallback((event) => {
         setSearch(event.currentTarget.value);
     }, []);
@@ -156,34 +177,68 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
                             />
                             <div className={styles['videos-container']}>
                                 {
-                                    videosForSeason
-                                        .filter((video) => {
-                                            return search.length === 0 ||
-                                                (
-                                                    (typeof video.title === 'string' && video.title.toLowerCase().includes(search.toLowerCase())) ||
-                                                    (!isNaN(video.released.getTime()) && video.released.toLocaleString(profile.settings.interfaceLanguage, { year: '2-digit', month: 'short', day: 'numeric' }).toLowerCase().includes(search.toLowerCase()))
+                                    (() => {
+                                        const uniqueSeasons = search.length > 0
+                                            ? [...new Set(filteredVideos.map((v) => v.season))]
+                                            : [];
+
+                                        // Only show season separators when there are multiple seasons in the results or the selected season is different
+                                        const showSeasonSeparators = uniqueSeasons.length > 1 ||
+                                            (uniqueSeasons.length === 1 && uniqueSeasons[0] !== selectedSeason);
+
+                                        const elements = [];
+                                        let currentSeason = null;
+
+                                        filteredVideos.forEach((video, index) => {
+                                            // Add season header when entering a new season
+                                            if (showSeasonSeparators && video.season !== currentSeason) {
+                                                currentSeason = video.season;
+                                                const isSelectedSeason = currentSeason === selectedSeason;
+                                                elements.push(
+                                                    <div
+                                                        key={`season-${currentSeason}`}
+                                                        className={classnames(
+                                                            styles['season-separator'],
+                                                            { [styles['season-separator--selected']]: isSelectedSeason }
+                                                        )}
+                                                        ref={isSelectedSeason ? (el) => {
+                                                            // Auto-scroll to current season when results load
+                                                            if (el) {
+                                                                requestAnimationFrame(() => {
+                                                                    el.scrollIntoView({ behavior: 'instant', block: 'start' });
+                                                                });
+                                                            }
+                                                        } : null}
+                                                    >
+                                                        {t('SEASON')} {currentSeason}
+                                                    </div>
                                                 );
-                                        })
-                                        .map((video, index) => (
-                                            <Video
-                                                key={index}
-                                                id={video.id}
-                                                title={video.title}
-                                                thumbnail={video.thumbnail}
-                                                season={video.season}
-                                                episode={video.episode}
-                                                released={video.released}
-                                                upcoming={video.upcoming}
-                                                watched={video.watched}
-                                                progress={video.progress}
-                                                deepLinks={video.deepLinks}
-                                                scheduled={video.scheduled}
-                                                seasonWatched={seasonWatched}
-                                                selected={video.id === selectedVideoId}
-                                                onMarkVideoAsWatched={onMarkVideoAsWatched}
-                                                onMarkSeasonAsWatched={onMarkSeasonAsWatched}
-                                            />
-                                        ))
+                                            }
+
+                                            elements.push(
+                                                <Video
+                                                    key={index}
+                                                    id={video.id}
+                                                    title={video.title}
+                                                    thumbnail={video.thumbnail}
+                                                    season={video.season}
+                                                    episode={video.episode}
+                                                    released={video.released}
+                                                    upcoming={video.upcoming}
+                                                    watched={video.watched}
+                                                    progress={video.progress}
+                                                    deepLinks={video.deepLinks}
+                                                    scheduled={video.scheduled}
+                                                    seasonWatched={seasonWatched}
+                                                    selected={video.id === selectedVideoId}
+                                                    onMarkVideoAsWatched={onMarkVideoAsWatched}
+                                                    onMarkSeasonAsWatched={onMarkSeasonAsWatched}
+                                                />
+                                            );
+                                        });
+
+                                        return elements;
+                                    })()
                                 }
                             </div>
                         </React.Fragment>

--- a/src/routes/MetaDetails/VideosList/VideosList.js
+++ b/src/routes/MetaDetails/VideosList/VideosList.js
@@ -73,6 +73,11 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
 
     const [search, setSearch] = React.useState('');
 
+    // Clear search when user switches seasons
+    React.useEffect(() => {
+        setSearch('');
+    }, [selectedSeason]);
+
     const filteredVideos = React.useMemo(() => {
         // When searching: use ALL videos across all seasons
         // When browsing normally: use only videos from selected season
@@ -96,6 +101,42 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
     const searchInputOnChange = React.useCallback((event) => {
         setSearch(event.currentTarget.value);
     }, []);
+
+    const selectedSeasonRef = React.useRef(null);
+    const videosContainerRef = React.useRef(null);
+
+    // Auto-scroll to selected season when search results load
+    React.useEffect(() => {
+        if (search.length > 0 && filteredVideos.length > 0) {
+            requestAnimationFrame(() => {
+                // Scroll to selected season if it has results
+                if (selectedSeasonRef.current) {
+                    selectedSeasonRef.current.scrollIntoView({ behavior: 'instant', block: 'start' });
+                }
+                // Otherwise scroll to top
+                else if (videosContainerRef.current) {
+                    videosContainerRef.current.scrollTop = 0;
+                }
+            });
+        }
+    }, [filteredVideos, search]);
+
+    // Compute seasons for rendering - when not searching, use [null] for single pass
+    const seasonsToRender = React.useMemo(() => {
+        if (search.length === 0) {
+            return [null]; // Browsing - single "invisible" season
+        }
+
+        const seasons = [...new Set(filteredVideos.map((v) => v.season))].sort((a, b) => a - b);
+
+        // Always include current season even if no results
+        if (selectedSeason !== null && !seasons.includes(selectedSeason)) {
+            seasons.push(selectedSeason);
+            seasons.sort((a, b) => a - b);
+        }
+
+        return seasons;
+    }, [search, filteredVideos, selectedSeason]);
 
     const onMarkVideoAsWatched = (video, watched) => {
         core.transport.dispatch({
@@ -175,49 +216,47 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
                                 value={search}
                                 onChange={searchInputOnChange}
                             />
-                            <div className={styles['videos-container']}>
+                            <div className={styles['videos-container']} ref={videosContainerRef}>
                                 {
-                                    (() => {
-                                        const uniqueSeasons = search.length > 0
-                                            ? [...new Set(filteredVideos.map((v) => v.season))]
-                                            : [];
+                                    seasonsToRender.flatMap((season, index) => {
+                                        const isSearching = search.length > 0;
+                                        const videosInSeason = season === null
+                                            ? filteredVideos
+                                            : filteredVideos.filter((v) => v.season === season);
 
-                                        // Only show season separators when there are multiple seasons in the results or the selected season is different
-                                        const showSeasonSeparators = uniqueSeasons.length > 1 ||
-                                            (uniqueSeasons.length === 1 && uniqueSeasons[0] !== selectedSeason);
+                                        const isSelectedSeason = season === selectedSeason;
+                                        const hasResults = videosInSeason.length > 0;
 
-                                        const elements = [];
-                                        let currentSeason = null;
+                                        const isCompletelyEmpty = isSearching && filteredVideos.length === 0 && index === 0;
+                                        const shouldShowEmptyMessage = isSearching && (isCompletelyEmpty || (isSelectedSeason && !hasResults));
 
-                                        filteredVideos.forEach((video, index) => {
-                                            // Add season header when entering a new season
-                                            if (showSeasonSeparators && video.season !== currentSeason) {
-                                                currentSeason = video.season;
-                                                const isSelectedSeason = currentSeason === selectedSeason;
-                                                elements.push(
-                                                    <div
-                                                        key={`season-${currentSeason}`}
-                                                        className={classnames(
-                                                            styles['season-separator'],
-                                                            { [styles['season-separator--selected']]: isSelectedSeason }
-                                                        )}
-                                                        ref={isSelectedSeason ? (el) => {
-                                                            // Auto-scroll to current season when results load
-                                                            if (el) {
-                                                                requestAnimationFrame(() => {
-                                                                    el.scrollIntoView({ behavior: 'instant', block: 'start' });
-                                                                });
-                                                            }
-                                                        } : null}
-                                                    >
-                                                        {t('SEASON')} {currentSeason}
-                                                    </div>
-                                                );
-                                            }
-
-                                            elements.push(
+                                        return [
+                                            // Season separator (only when searching and not completely empty)
+                                            ...(isSearching && !isCompletelyEmpty ? [
+                                                <div
+                                                    key={`season-${season}`}
+                                                    className={classnames(
+                                                        styles['season-separator'],
+                                                        {
+                                                            [styles['season-separator--selected']]: isSelectedSeason,
+                                                            [styles['season-separator--empty']]: !hasResults
+                                                        }
+                                                    )}
+                                                    ref={isSelectedSeason && hasResults ? selectedSeasonRef : null}
+                                                >
+                                                    {t('SEASON')} {season}
+                                                </div>
+                                            ] : []),
+                                            // Empty message
+                                            ...(shouldShowEmptyMessage ? [
+                                                <div key={isCompletelyEmpty ? 'empty-all' : `empty-${season}`} className={styles['empty-message']}>
+                                                    {t('SEARCH_NO_RESULTS')}
+                                                </div>
+                                            ] : []),
+                                            // Videos
+                                            ...videosInSeason.map((video) => (
                                                 <Video
-                                                    key={index}
+                                                    key={video.id}
                                                     id={video.id}
                                                     title={video.title}
                                                     thumbnail={video.thumbnail}
@@ -234,11 +273,9 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
                                                     onMarkVideoAsWatched={onMarkVideoAsWatched}
                                                     onMarkSeasonAsWatched={onMarkSeasonAsWatched}
                                                 />
-                                            );
-                                        });
-
-                                        return elements;
-                                    })()
+                                            ))
+                                        ];
+                                    })
                                 }
                             </div>
                         </React.Fragment>

--- a/src/routes/MetaDetails/VideosList/styles.less
+++ b/src/routes/MetaDetails/VideosList/styles.less
@@ -72,6 +72,16 @@
         padding: 0 1rem;
         overflow-y: auto;
 
+        .empty-message {
+            flex: none;
+            align-self: stretch;
+            padding: 2rem 1rem;
+            text-align: center;
+            font-size: 1.2rem;
+            color: var(--primary-foreground-color);
+            opacity: 0.6;
+        }
+
         .season-separator {
             flex: none;
             align-self: stretch;
@@ -90,6 +100,11 @@
             &--selected {
                 opacity: 1;
                 font-weight: 700;
+            }
+
+            &--empty {
+                opacity: 0.5;
+                font-style: italic;
             }
         }
     }

--- a/src/routes/MetaDetails/VideosList/styles.less
+++ b/src/routes/MetaDetails/VideosList/styles.less
@@ -71,6 +71,27 @@
         align-self: stretch;
         padding: 0 1rem;
         overflow-y: auto;
+
+        .season-separator {
+            flex: none;
+            align-self: stretch;
+            padding: 1rem 0.5rem 0.5rem;
+            margin-top: 0.5rem;
+            font-size: 1.1rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            color: var(--primary-foreground-color);
+            opacity: 0.7;
+
+            &:first-child {
+                margin-top: 0;
+            }
+
+            &--selected {
+                opacity: 1;
+                font-weight: 700;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Search now works across all seasons instead of just current season 
Added season separators with highlighting for current season (only when search results are from different season)
Auto-scroll to selected season in search results (to keep the original behavior, you always see the results from selected season this way)

<img width="345" height="486" alt="image" src="https://github.com/user-attachments/assets/4b151c4e-e7d6-4912-99c3-cbfd00d6466a" />
