### PR TITLE
[Feature]: Add copy magnet link option

### DIFF
--- a/src/routes/MetaDetails/StreamsList/Stream/Stream.js
+++ b/src/routes/MetaDetails/StreamsList/Stream/Stream.js
@@ -3,6 +3,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const classnames = require('classnames');
+const magnet = require('magnet-uri');
 const { default: Icon } = require('@stremio/stremio-icons/react');
 const { t } = require('i18next');
 const { useProfile, usePlatform, useToast, useBinaryState } = require('stremio/common');
@@ -12,7 +13,7 @@ const { useRouteFocused } = require('stremio-router');
 const StreamPlaceholder = require('./StreamPlaceholder');
 const styles = require('./styles');
 
-const Stream = ({ className, videoId, videoReleased, addonName, name, description, thumbnail, progress, deepLinks, ...props }) => {
+const Stream = ({ className, videoId, videoReleased, addonName, name, description, thumbnail, progress, deepLinks, infoHash, sources, ...props }) => {
     const profile = useProfile();
     const toast = useToast();
     const platform = usePlatform();
@@ -164,6 +165,44 @@ const Stream = ({ className, videoId, videoReleased, addonName, name, descriptio
         }
     }, [streamLink]);
 
+    const magnetLink = React.useMemo(() => {
+        if (typeof infoHash !== 'string' || infoHash.length === 0) {
+            return null;
+        }
+        const params = { xt: `urn:btih:${infoHash}` };
+        if (typeof name === 'string' && name.length > 0) {
+            params.dn = name;
+        } else if (typeof addonName === 'string' && addonName.length > 0) {
+            params.dn = addonName;
+        }
+        if (Array.isArray(sources) && sources.length > 0) {
+            params.tr = sources.filter((s) => typeof s === 'string' && s.length > 0);
+        }
+        return magnet.encode(params);
+    }, [infoHash, sources, name, addonName]);
+
+    const copyMagnetLink = React.useCallback((event) => {
+        event.preventDefault();
+        closeMenu();
+        if (magnetLink) {
+            navigator.clipboard.writeText(magnetLink)
+                .then(() => {
+                    toast.show({
+                        type: 'success',
+                        title: t('PLAYER_COPY_MAGNET_LINK_SUCCESS', 'Magnet link was copied to your clipboard'),
+                        timeout: 4000
+                    });
+                })
+                .catch(() => {
+                    toast.show({
+                        type: 'error',
+                        title: t('PLAYER_COPY_MAGNET_LINK_ERROR', 'Failed to copy magnet link'),
+                        timeout: 4000,
+                    });
+                });
+        }
+    }, [magnetLink]);
+
     const renderThumbnailFallback = React.useCallback(() => (
         <Icon className={styles['placeholder-icon']} name={'ic_broken_link'} />
     ), []);
@@ -228,9 +267,16 @@ const Stream = ({ className, videoId, videoReleased, addonName, name, descriptio
                             <div className={styles['context-menu-option-label']}>{t('CTX_COPY_VIDEO_DOWNLOAD_LINK')}</div>
                         </Button>
                 }
+                {
+                    magnetLink &&
+                        <Button className={styles['context-menu-option-container']} title={t('CTX_COPY_MAGNET_LINK', 'Copy magnet link')} onClick={copyMagnetLink}>
+                            <Icon className={styles['menu-icon']} name={'magnet-link'} />
+                            <div className={styles['context-menu-option-label']}>{t('CTX_COPY_MAGNET_LINK', 'Copy magnet link')}</div>
+                        </Button>
+                }
             </div>
         );
-    }, [copyStreamLink, onClick]);
+    }, [copyStreamLink, copyMagnetLink, onClick]);
 
     React.useEffect(() => {
         if (!routeFocused) {
@@ -280,6 +326,8 @@ Stream.propTypes = {
             })
         })
     }),
+    infoHash: PropTypes.string,
+    sources: PropTypes.arrayOf(PropTypes.string),
     onClick: PropTypes.func
 };
 

--- a/src/routes/MetaDetails/StreamsList/StreamsList.js
+++ b/src/routes/MetaDetails/StreamsList/StreamsList.js
@@ -191,6 +191,8 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
                                             thumbnail={stream.thumbnail}
                                             progress={stream.progress}
                                             deepLinks={stream.deepLinks}
+                                            infoHash={stream.infoHash}
+                                            sources={stream.sources}
                                             onClick={stream.onClick}
                                         />
                                     ))}

--- a/src/routes/Player/OptionsMenu/OptionsMenu.js
+++ b/src/routes/Player/OptionsMenu/OptionsMenu.js
@@ -3,6 +3,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 const classnames = require('classnames');
+const magnet = require('magnet-uri');
 const { useTranslation } = require('react-i18next');
 const { usePlatform, useToast } = require('stremio/common');
 const { useServices } = require('stremio/services');
@@ -30,6 +31,43 @@ const OptionsMenu = ({ className, stream, playbackDevices, extraSubtitlesTracks,
         const track = extraSubtitlesTracks?.find(({ id }) => id === selectedExtraSubtitlesTrackId);
         return track?.fallbackUrl ?? track?.url ?? null;
     }, [extraSubtitlesTracks, selectedExtraSubtitlesTrackId]);
+
+    const magnetLink = React.useMemo(() => {
+        if (stream === null || typeof stream.infoHash !== 'string' || stream.infoHash.length === 0) {
+            return null;
+        }
+        const params = { xt: `urn:btih:${stream.infoHash}` };
+        if (typeof stream.name === 'string' && stream.name.length > 0) {
+            params.dn = stream.name;
+        }
+        if (Array.isArray(stream.sources) && stream.sources.length > 0) {
+            params.tr = stream.sources.filter((s) => typeof s === 'string' && s.length > 0);
+        }
+        return magnet.encode(params);
+    }, [stream]);
+
+    const onCopyMagnetLinkClick = React.useCallback(() => {
+        if (magnetLink) {
+            navigator.clipboard.writeText(magnetLink)
+                .then(() => {
+                    toast.show({
+                        type: 'success',
+                        title: 'Copied',
+                        message: t('PLAYER_COPY_MAGNET_LINK_SUCCESS', 'Magnet link was copied to your clipboard'),
+                        timeout: 3000
+                    });
+                })
+                .catch((e) => {
+                    console.error(e);
+                    toast.show({
+                        type: 'error',
+                        title: t('Error'),
+                        message: t('PLAYER_COPY_MAGNET_LINK_ERROR', 'Failed to copy magnet link'),
+                        timeout: 3000
+                    });
+                });
+        }
+    }, [magnetLink]);
 
     const onCopyStreamButtonClick = React.useCallback(() => {
         if (streamingUrl || downloadUrl) {
@@ -101,6 +139,17 @@ const OptionsMenu = ({ className, stream, playbackDevices, extraSubtitlesTracks,
                         label={t('CTX_DOWNLOAD_VIDEO')}
                         disabled={stream === null}
                         onClick={onDownloadVideoButtonClick}
+                    />
+                    :
+                    null
+            }
+            {
+                magnetLink ?
+                    <Option
+                        icon={'magnet-link'}
+                        label={t('CTX_COPY_MAGNET_LINK', 'Copy magnet link')}
+                        disabled={stream === null}
+                        onClick={onCopyMagnetLinkClick}
                     />
                     :
                     null


### PR DESCRIPTION
Closes #1128

Adds a "**Copy magnet link**" option to the stream context menu and to the player options menu.

Builds the magnet URI from the `infoHash` and `sources` fields already available in the stream data, using the existing `magnet-uri` dependency. The option only shows for torrent-based streams.

Uses the `magnet-link` icon from `@stremio/stremio-icons`.

Translation keys (`CTX_COPY_MAGNET_LINK`, `PLAYER_COPY_MAGNET_LINK_SUCCESS`, `PLAYER_COPY_MAGNET_LINK_ERROR`) use inline fallbacks until they are added to `stremio-translations`.