### PR TITLE
feat(Discover): show loading bar during pagination

### DIFF
--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -172,6 +172,11 @@ const Discover = ({ urlParams, queryParams }) => {
                                                 onClick={metaItemOnClick}
                                             />
                                         ))}
+                                        {discover.selectable.loadingNextPage &&
+                                            <div className={styles['pagination-loading']}>
+                                                <div className={styles['pagination-loading-bar']} />
+                                            </div>
+                                        }
                                     </div>
                     }
                 </div>

--- a/src/routes/Discover/styles.less
+++ b/src/routes/Discover/styles.less
@@ -206,6 +206,43 @@
                         }
                     }
                 }
+
+                .pagination-loading {
+                    grid-column: 1 / -1;
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    padding: 3rem 0;
+
+                    .pagination-loading-bar {
+                        position: relative;
+                        width: 20rem;
+                        max-width: 60%;
+                        height: 0.25rem;
+                        border-radius: var(--border-radius);
+                        background-color: var(--color-placeholder-background);
+                        overflow: hidden;
+
+                        &::after {
+                            content: '';
+                            position: absolute;
+                            top: 0;
+                            left: 0;
+                            width: 40%;
+                            height: 100%;
+                            border-radius: var(--border-radius);
+                            background-color: var(--primary-accent-color);
+                            animation: pagination-loading-slide 1.5s ease-in-out infinite;
+                        }
+
+                        @media (prefers-reduced-motion) {
+                            &::after {
+                                width: 100%;
+                                animation: pagination-loading-pulse 2s ease-in-out infinite;
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -245,6 +282,26 @@
                 }
             }
         }
+    }
+}
+
+@keyframes pagination-loading-slide {
+    0% {
+        left: -40%;
+    }
+
+    100% {
+        left: 100%;
+    }
+}
+
+@keyframes pagination-loading-pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.3;
     }
 }
 

--- a/src/types/models/Discover.d.ts
+++ b/src/types/models/Discover.d.ts
@@ -19,6 +19,7 @@ type Discover = {
         extra: SelectableExtra<DiscoverDeepLinks>[],
         types: SelectableType<DiscoverDeepLinks>[],
         nextPage: boolean,
+        loadingNextPage: boolean,
     },
     selected: {
         request: ResourceRequest,


### PR DESCRIPTION
## Summary
- Render an animated loading bar at the bottom of the Discover catalog grid while the next page is being fetched
- Driven by the new `loadingNextPage` field from stremio-core's Discover serializer
- Includes `prefers-reduced-motion` fallback

Depends on: Stremio/stremio-core#932 (core-web release with `loadingNextPage`)