### PR TITLE
PWA: navigation bar styles, fullscreen, safe areas

### DIFF
--- a/src/App/styles.less
+++ b/src/App/styles.less
@@ -23,8 +23,8 @@
 // HTML sizes
 @html-width: ~"calc(max(var(--small-viewport-width), var(--dynamic-viewport-width)))";
 @html-height: ~"calc(max(var(--small-viewport-height), var(--dynamic-viewport-height)))";
-@html-standalone-width: ~"calc(max(100%, var(--small-viewport-width)))";
-@html-standalone-height: ~"calc(max(100%, var(--small-viewport-height)))";
+@html-standalone-width: ~"calc(max(100%, var(--large-viewport-width)))";
+@html-standalone-height: ~"calc(max(100%, var(--large-viewport-height)))";
 
 // Safe area insets
 @safe-area-inset-top: env(safe-area-inset-top, 0rem);
@@ -102,7 +102,7 @@
     }
 
     @media (display-mode: standalone) {
-        --safe-area-inset-bottom: 0rem;
+        --safe-area-inset-bottom: @calculated-bottom-safe-inset;
     }
 }
 

--- a/src/App/styles.less
+++ b/src/App/styles.less
@@ -156,7 +156,8 @@ html {
     overscroll-behavior: none;
     user-select: none;
     touch-action: manipulation;
-    background-color: var(--primary-background-color);
+    background-color: var(--secondary-background-color);
+    background: linear-gradient(41deg, var(--primary-background-color) 0%, var(--secondary-background-color) 100%);
     -webkit-tap-highlight-color: transparent;
 
     @media (display-mode: standalone) {

--- a/src/App/styles.less
+++ b/src/App/styles.less
@@ -156,6 +156,7 @@ html {
     overscroll-behavior: none;
     user-select: none;
     touch-action: manipulation;
+    background-color: var(--primary-background-color);
     -webkit-tap-highlight-color: transparent;
 
     @media (display-mode: standalone) {

--- a/src/App/styles.less
+++ b/src/App/styles.less
@@ -157,7 +157,6 @@ html {
     user-select: none;
     touch-action: manipulation;
     background-color: var(--secondary-background-color);
-    background: linear-gradient(41deg, var(--primary-background-color) 0%, var(--secondary-background-color) 100%);
     -webkit-tap-highlight-color: transparent;
 
     @media (display-mode: standalone) {

--- a/src/App/styles.less
+++ b/src/App/styles.less
@@ -102,7 +102,7 @@
     }
 
     @media (display-mode: standalone) {
-        --safe-area-inset-bottom: @calculated-bottom-safe-inset;
+        --safe-area-inset-bottom: 0rem;
     }
 }
 
@@ -156,7 +156,7 @@ html {
     overscroll-behavior: none;
     user-select: none;
     touch-action: manipulation;
-    background-color: var(--secondary-background-color);
+    background-color: var(--primary-background-color);
     -webkit-tap-highlight-color: transparent;
 
     @media (display-mode: standalone) {

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=0, user-scalable=no, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Stremio">
     <link rel="icon" type="image/x-icon" href="<%= htmlWebpackPlugin.options.faviconsPath %>/favicon.ico">
     <link rel="manifest" href="manifest.json" />

--- a/src/routes/Player/SideDrawer/SideDrawer.less
+++ b/src/routes/Player/SideDrawer/SideDrawer.less
@@ -13,6 +13,7 @@
     display: flex;
     flex-direction: column;
     padding: @padding;
+    padding-top: calc(@padding + var(--safe-area-inset-top));
     height: 100dvh;
     max-width: 35rem;
     overflow-y: auto;
@@ -28,7 +29,7 @@
     .close-button {
         display: none;
         position: absolute;
-        top: 1.3rem;
+        top: calc(1.3rem + var(--safe-area-inset-top));
         right: 1.3rem;
         padding: 0.5rem;
         background-color: transparent;
@@ -87,11 +88,9 @@
 @media @phone-portrait {
     .side-drawer {
         max-width: 100dvw;
-        padding-top: calc(@padding + var(--safe-area-inset-top));
 
         .close-button {
             display: block;
-            top: calc(1.3rem + var(--safe-area-inset-top));
         }
     }
 }

--- a/src/routes/Player/SideDrawer/SideDrawer.less
+++ b/src/routes/Player/SideDrawer/SideDrawer.less
@@ -87,9 +87,11 @@
 @media @phone-portrait {
     .side-drawer {
         max-width: 100dvw;
+        padding-top: calc(@padding + var(--safe-area-inset-top));
 
         .close-button {
             display: block;
+            top: calc(1.3rem + var(--safe-area-inset-top));
         }
     }
 }


### PR DESCRIPTION
- after ios26 the bar went back to white
- the safe area inset was white causing the app to look bad :D
- SideDrawer did not respect safe areas