### PR TITLE
fix: use valid translation keys

### DIFF
--- a/src/routes/MetaDetails/VideosList/SeasonsBar/SeasonsBarPlaceholder/SeasonsBarPlaceholder.js
+++ b/src/routes/MetaDetails/VideosList/SeasonsBar/SeasonsBarPlaceholder/SeasonsBarPlaceholder.js
@@ -13,14 +13,14 @@ const SeasonsBarPlaceholder = ({ className }) => {
         <div className={classnames(className, styles['seasons-bar-placeholder-container'])}>
             <div className={styles['prev-season-button']}>
                 <Icon className={styles['icon']} name={'chevron-back'} />
-                <div className={styles['label']}>{t('SEASON_PREV')}</div>
+                <div className={styles['label']}>{t('PREV_SEASON')}</div>
             </div>
             <div className={styles['seasons-popup-label-container']}>
                 <div className={styles['seasons-popup-label']}>{t('SEASON_NUMBER', { season: 1 })}</div>
                 <Icon className={styles['seasons-popup-icon']} name={'caret-down'} />
             </div>
             <div className={styles['next-season-button']}>
-                <div className={styles['label']}>{t('SEASON_NEXT')}</div>
+                <div className={styles['label']}>{t('NEXT_SEASON')}</div>
                 <Icon className={styles['icon']} name={'chevron-forward'} />
             </div>
         </div>

--- a/src/routes/Player/OptionsMenu/OptionsMenu.js
+++ b/src/routes/Player/OptionsMenu/OptionsMenu.js
@@ -46,7 +46,7 @@ const OptionsMenu = ({ className, stream, playbackDevices, extraSubtitlesTracks,
                     console.error(e);
                     toast.show({
                         type: 'error',
-                        title: t('Error'),
+                        title: t('ERROR'),
                         message: `${t('PLAYER_COPY_STREAM_ERROR')}: ${streamingUrl || downloadUrl}`,
                         timeout: 3000
                     });


### PR DESCRIPTION
## Summary
- Replace invalid `t('Error')` with `t('ERROR')` in player options menu
- Replace missing keys `SEASON_PREV`/`SEASON_NEXT` with existing `PREV_SEASON`/`NEXT_SEASON`

## Validation
- `pnpm run scan-translations` passes
- Key usage check shows no missing static keys in `en-US` (only dynamic `TORRENT_PROFILE_` pattern remains)
