### PR TITLE
Fix: Add trailing slash to COPY destination path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /var/www/stremio-web
 # Setup app
 FROM base AS app
 
-COPY package.json pnpm-lock.yaml /var/www/stremio-web
+COPY package.json pnpm-lock.yaml /var/www/stremio-web/
 RUN pnpm i --frozen-lockfile
 
 COPY . /var/www/stremio-web


### PR DESCRIPTION
The COPY command on line 11 copies multiple source files to a destination 
path without a trailing slash, which causes Docker to throw an error:

"When using COPY with more than one source file, the destination must be 
a directory and end with a /"

Adding the trailing slash explicitly tells Docker the destination is a 
directory, resolving the build error.