### PR TITLE
feature - Add addons reorder capabilities

### DIFF
--- a/src/routes/Addons/Addon/Addon.js
+++ b/src/routes/Addons/Addon/Addon.js
@@ -8,7 +8,7 @@ const { default: Icon } = require('@stremio/stremio-icons/react');
 const { Button, Image } = require('stremio/components');
 const styles = require('./styles');
 
-const Addon = ({ className, id, name, version, logo, description, types, behaviorHints, installed, onInstall, onUninstall, onConfigure, onOpen, onShare, dataset }) => {
+const Addon = ({ className, id, name, version, logo, description, types, behaviorHints, installed, canMoveUp, canMoveDown, reorderDisabled, onInstall, onUninstall, onConfigure, onOpen, onShare, onMoveUp, onMoveDown, dataset }) => {
     const { t } = useTranslation();
     const onInstallClick = React.useCallback((event) => {
         event.stopPropagation();
@@ -65,6 +65,18 @@ const Addon = ({ className, id, name, version, logo, description, types, behavio
             });
         }
     }, [onShare, dataset]);
+    const moveUpButtonOnClick = React.useCallback((event) => {
+        event.stopPropagation();
+        if (typeof onMoveUp === 'function') {
+            onMoveUp(dataset.addon);
+        }
+    }, [onMoveUp, dataset]);
+    const moveDownButtonOnClick = React.useCallback((event) => {
+        event.stopPropagation();
+        if (typeof onMoveDown === 'function') {
+            onMoveDown(dataset.addon);
+        }
+    }, [onMoveDown, dataset]);
     const onKeyDown = React.useCallback((event) => {
         if (event.key === 'Enter') {
             onOpenClick(event);
@@ -75,6 +87,31 @@ const Addon = ({ className, id, name, version, logo, description, types, behavio
     ), []);
     return (
         <Button className={classnames(className, styles['addon-container'])} onKeyDown={onKeyDown} onClick={onOpenClick}>
+            {
+                installed && (typeof onMoveUp === 'function' || typeof onMoveDown === 'function') ?
+                    <div className={styles['reorder-buttons-container']}>
+                        <Button
+                            className={styles['reorder-button-container']}
+                            title={t('BUTTON_PREV')}
+                            tabIndex={-1}
+                            disabled={!canMoveUp || reorderDisabled}
+                            onClick={moveUpButtonOnClick}
+                        >
+                            <Icon className={styles['icon']} name={'chevron-up'} />
+                        </Button>
+                        <Button
+                            className={styles['reorder-button-container']}
+                            title={t('BUTTON_NEXT')}
+                            tabIndex={-1}
+                            disabled={!canMoveDown || reorderDisabled}
+                            onClick={moveDownButtonOnClick}
+                        >
+                            <Icon className={styles['icon']} name={'chevron-down'} />
+                        </Button>
+                    </div>
+                    :
+                    null
+            }
             <div className={styles['logo-container']}>
                 <Image
                     className={styles['logo']}
@@ -156,12 +193,17 @@ Addon.propTypes = {
         p2p: PropTypes.bool,
     }),
     installed: PropTypes.bool,
+    canMoveUp: PropTypes.bool,
+    canMoveDown: PropTypes.bool,
+    reorderDisabled: PropTypes.bool,
     onToggle: PropTypes.func,
     onInstall: PropTypes.func,
     onUninstall: PropTypes.func,
     onConfigure: PropTypes.func,
     onOpen: PropTypes.func,
     onShare: PropTypes.func,
+    onMoveUp: PropTypes.func,
+    onMoveDown: PropTypes.func,
     dataset: PropTypes.object
 };
 

--- a/src/routes/Addons/Addon/styles.less
+++ b/src/routes/Addons/Addon/styles.less
@@ -4,6 +4,7 @@
 @import (reference) '~stremio/common/screen-sizes.less';
 
 .addon-container {
+    position: relative;
     display: flex;
     flex-direction: row;
     align-items: flex-start;
@@ -16,6 +17,41 @@
 
     &:hover {
         border-color: var(--overlay-color);
+    }
+
+    .reorder-buttons-container {
+        position: absolute;
+        top: 1rem;
+        left: 1rem;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+
+        .reorder-button-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 2rem;
+            height: 2rem;
+            border-radius: 50%;
+            background-color: var(--overlay-color);
+
+            &:hover:not(:disabled) {
+                outline: var(--focus-outline-size) solid var(--primary-foreground-color);
+            }
+
+            &:disabled {
+                opacity: 0.35;
+                cursor: default;
+            }
+
+            .icon {
+                width: 1rem;
+                height: 1rem;
+                color: var(--primary-foreground-color);
+            }
+        }
     }
 
     .logo-container {
@@ -203,6 +239,11 @@
 @media only screen and (max-width: @minimum) {
     .addon-container {
         flex-wrap: wrap;
+
+        .reorder-buttons-container {
+            top: 0.75rem;
+            left: 0.75rem;
+        }
 
         .info-container {
             margin-left: 0.5rem;

--- a/src/routes/Addons/Addons.js
+++ b/src/routes/Addons/Addons.js
@@ -5,7 +5,7 @@ const PropTypes = require('prop-types');
 const classnames = require('classnames');
 const { useTranslation } = require('react-i18next');
 const { default: Icon } = require('@stremio/stremio-icons/react');
-const { usePlatform, useBinaryState, withCoreSuspender } = require('stremio/common');
+const { usePlatform, useBinaryState, useProfile, withCoreSuspender } = require('stremio/common');
 const { AddonDetailsModal, Button, Image, MainNavBars, ModalDialog, SearchBar, SharePrompt, TextInput, MultiselectMenu } = require('stremio/components');
 const { useServices } = require('stremio/services');
 const useToast = require('stremio/common/Toast/useToast');
@@ -20,6 +20,7 @@ const { AddonPlaceholder } = require('./AddonPlaceholder');
 const Addons = ({ urlParams, queryParams }) => {
     const { t } = useTranslation();
     const platform = usePlatform();
+    const profile = useProfile();
     const { core } = useServices();
     const toast = useToast();
     const installedAddons = useInstalledAddons(urlParams);
@@ -62,6 +63,7 @@ const Addons = ({ urlParams, queryParams }) => {
         ];
     }, [addAddonOnSubmit]);
     const [search, setSearch] = React.useState('');
+    const [reorderSaving, setReorderSaving] = React.useState(false);
     const searchInputOnChange = React.useCallback((event) => {
         setSearch(event.currentTarget.value);
     }, []);
@@ -90,6 +92,19 @@ const Addons = ({ urlParams, queryParams }) => {
             }
         });
     }, []);
+    const onAddonOrderUpdated = React.useCallback((fromIndex, toIndex) => {
+        const addons = profile.addons.slice();
+        const [addon] = addons.splice(fromIndex, 1);
+        addons.splice(toIndex, 0, addon);
+
+        return core.transport.dispatch({
+            action: 'Ctx',
+            args: {
+                action: 'UpdateAddons',
+                args: addons,
+            }
+        });
+    }, [core.transport, profile.addons]);
     const onAddonConfigure = React.useCallback((event) => {
         platform.openExternal(event.dataset.addon.transportUrl.replace('manifest.json', 'configure'));
     }, []);
@@ -106,6 +121,56 @@ const Addons = ({ urlParams, queryParams }) => {
                 (typeof addon.manifest.description === 'string' && addon.manifest.description.toLowerCase().includes(search.toLowerCase()))
             );
     }, [search]);
+    const canReorderAddons = (
+        typeof profile.auth?.key === 'string' &&
+        profile.auth.key.length > 0 &&
+        profile.addonsLocked !== true &&
+        Array.isArray(profile.addons) &&
+        profile.addons.length > 0
+    );
+    const visibleInstalledAddonsWithIndexes = React.useMemo(() => (
+        installedAddons.catalog
+            .map((addon, index) => ({ addon, index }))
+            .filter(({ addon }) => searchFilterPredicate(addon))
+    ), [installedAddons.catalog, searchFilterPredicate]);
+    const visibleInstalledAddons = React.useMemo(() => (
+        visibleInstalledAddonsWithIndexes.map(({ addon }) => addon)
+    ), [visibleInstalledAddonsWithIndexes]);
+    const moveAddon = React.useCallback(async (addon, direction) => {
+        if (!canReorderAddons || reorderSaving) {
+            return;
+        }
+
+        const visibleIndex = visibleInstalledAddonsWithIndexes.findIndex(({ addon: visibleAddon }) => visibleAddon === addon);
+        const targetVisibleIndex = direction === 'up' ? visibleIndex - 1 : visibleIndex + 1;
+
+        if (
+            visibleIndex === -1 ||
+            targetVisibleIndex < 0 ||
+            targetVisibleIndex >= visibleInstalledAddonsWithIndexes.length
+        ) {
+            return;
+        }
+
+        const fromIndex = visibleInstalledAddonsWithIndexes[visibleIndex].index;
+        const toIndex = visibleInstalledAddonsWithIndexes[targetVisibleIndex].index;
+
+        setReorderSaving(true);
+
+        try {
+            await onAddonOrderUpdated(fromIndex, toIndex);
+        } catch (error) {
+            console.error('Failed to save addon order:', error);
+        } finally {
+            setReorderSaving(false);
+        }
+    }, [canReorderAddons, onAddonOrderUpdated, reorderSaving, visibleInstalledAddonsWithIndexes]);
+    const moveAddonUp = React.useCallback((addon) => {
+        return moveAddon(addon, 'up');
+    }, [moveAddon]);
+    const moveAddonDown = React.useCallback((addon) => {
+        return moveAddon(addon, 'down');
+    }, [moveAddon]);
     const renderLogoFallback = React.useCallback(() => (
         <Icon className={styles['icon']} name={'addons'} />
     ), []);
@@ -154,8 +219,7 @@ const Addons = ({ urlParams, queryParams }) => {
                                 :
                                 <div className={styles['addons-list-container']}>
                                     {
-                                        installedAddons.catalog
-                                            .filter(searchFilterPredicate)
+                                        visibleInstalledAddons
                                             .map((addon, index) => (
                                                 <Addon
                                                     key={index}
@@ -173,6 +237,11 @@ const Addons = ({ urlParams, queryParams }) => {
                                                     onConfigure={onAddonConfigure}
                                                     onOpen={onAddonOpen}
                                                     onShare={onAddonShare}
+                                                    canMoveUp={canReorderAddons && index > 0}
+                                                    canMoveDown={canReorderAddons && index < visibleInstalledAddons.length - 1}
+                                                    reorderDisabled={canReorderAddons ? reorderSaving : undefined}
+                                                    onMoveUp={canReorderAddons ? moveAddonUp : undefined}
+                                                    onMoveDown={canReorderAddons ? moveAddonDown : undefined}
                                                     dataset={{ addon }}
                                                 />
                                             ))


### PR DESCRIPTION
Add addon reorder capabilities in the web version.
Only available when logged in.

Requires an update in the core beforehand : https://github.com/Stremio/stremio-core/pull/946 

There is currently no way to reorder addons within Stremio. Adding this capability to the web version would be a significant improvement.
Today, users rely on external plugins, websites, or tools to reorder their addons. This approach is inherently risky, as these third‑party solutions cannot be fully trusted.

<img width="662" height="585" alt="image" src="https://github.com/user-attachments/assets/f2d693fd-023a-497e-aff4-9ff5d4dacc38" />
