### PR TITLE
fix: use addon-provided subtitle label instead of URL

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -369,7 +369,7 @@ const Player = ({ urlParams, queryParams }) => {
                     subtitles: Array.isArray(player.selected.stream.subtitles) ?
                         player.selected.stream.subtitles.map((subtitles) => ({
                             ...subtitles,
-                            label: subtitles.url
+                            label: subtitles.label || subtitles.url
                         }))
                         :
                         []
@@ -406,7 +406,7 @@ const Player = ({ urlParams, queryParams }) => {
         if (video.state.stream !== null) {
             const tracks = player.subtitles.map((subtitles) => ({
                 ...subtitles,
-                label: subtitles.url
+                label: subtitles.label || subtitles.url
             }));
             video.addExtraSubtitlesTracks(tracks);
         }


### PR DESCRIPTION
Closes #1166

## Problem

`Player.js` overwrites the addon-provided `label` with the subtitle URL in two places, making the `label` field added in [stremio-core#947](https://github.com/Stremio/stremio-core/pull/947) (v0.55.0) unusable.

This forces subtitle addons to put custom text in the `lang` field as a workaround, which breaks on Android where `java.util.Locale` shows "Unknown (und)" for non-ISO values.

## Fix

Prefer the addon-provided `label` when present, fall back to URL (current behavior) when not:

```diff
- label: subtitles.url
+ label: subtitles.label || subtitles.url
```

Applied at both locations in Player.js (stream subtitles + addon extra subtitles).

The downstream display logic in `SubtitlesMenu.js` ([PR #688](https://github.com/Stremio/stremio-web/pull/688)) already handles non-URL labels correctly:
```js
languages.label(!track.label.startsWith('http') ? track.label : track.lang)
```

No other changes needed.

## Related

- [stremio-core#947](https://github.com/Stremio/stremio-core/pull/947) - Added `label: Option<String>` to `Subtitles`
- [stremio-core-kotlin#109](https://github.com/Stremio/stremio-core-kotlin/issues/109) - Companion issue for Android protobuf bridge
- [stremio-bugs#544](https://github.com/AntaresApp/stremio-bugs/issues/544) - Android TV subtitle name issues