### PR TITLE
fix: improve episode title formatting in StreamsList component

### DIFF
--- a/src/routes/MetaDetails/StreamsList/StreamsList.js
+++ b/src/routes/MetaDetails/StreamsList/StreamsList.js
@@ -108,7 +108,9 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
                                 <Icon className={styles['icon']} name={'chevron-back'} />
                             </Button>
                             <div className={styles['episode-title']}>
-                                {`S${video?.season}E${video?.episode} ${(video?.title)}`}
+                                {typeof video.season === 'number' && typeof video.episode === 'number'
+                                    ? `S${video.season}E${video.episode}${video.title ? ` ${video.title}` : ''}`
+                                    : (video.title ?? '')}
                             </div>
                         </React.Fragment>
                         :


### PR DESCRIPTION
## Summary
Fixes the streams list header showing `SundefinedEundefined` when `video.season` or `video.episode` are not set.

<img width="514" height="78" alt="image" src="https://github.com/user-attachments/assets/aea1f729-6d2e-45a8-82aa-373e9df0cefb" />

## Changes
- Only prefix with `S{season}E{episode}` when both values are numbers.
- Otherwise render `video.title` only.

<img width="508" height="72" alt="image" src="https://github.com/user-attachments/assets/eb4cfa91-9ef9-4268-82e2-51ebaeb49e97" />

## Before / After
- **Before:** `SundefinedEundefined Batman vs. Robin`
- **After:** `Batman vs. Robin`

## Notes
No API or addon changes; UI-only fix in `StreamsList`.