### PR TITLE
fix: shift subtitles above control bar when controls are visible

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -510,9 +510,13 @@ const Player = ({ urlParams, queryParams }) => {
     }, [video.state.stream, player.streamState]);
 
     React.useEffect(() => {
-        const base = settings.subtitlesOffset ?? 0;
-        video.setSubtitlesOffset(overlayHidden ? base : Math.min(100, base + CONTROL_BAR_SUBTITLE_BUMP));
-    }, [overlayHidden, settings.subtitlesOffset]);
+        if (video.state.stream === null || video.state.subtitlesOffset === null) return;
+        const base = player.streamState?.subtitleOffset ?? settings.subtitlesOffset ?? 0;
+        const desired = overlayHidden ? base : Math.min(100, base + CONTROL_BAR_SUBTITLE_BUMP);
+        if (video.state.subtitlesOffset !== desired) {
+            video.setSubtitlesOffset(desired);
+        }
+    }, [overlayHidden, settings.subtitlesOffset, player.streamState, video.state.subtitlesOffset, video.state.stream]);
 
     React.useEffect(() => {
         defaultSubtitlesSelected.current = false;

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -31,6 +31,7 @@ const { default: Indicator } = require('./Indicator/Indicator');
 
 const findTrackByLang = (tracks, lang) => tracks.find((track) => track.lang === lang || langs.where('1', track.lang)?.[2] === lang);
 const findTrackById = (tracks, id) => tracks.find((track) => track.id === id);
+const CONTROL_BAR_SUBTITLE_BUMP = 8;
 
 const Player = ({ urlParams, queryParams }) => {
     const { t } = useTranslation();
@@ -507,6 +508,11 @@ const Player = ({ urlParams, queryParams }) => {
             }
         }
     }, [video.state.stream, player.streamState]);
+
+    React.useEffect(() => {
+        const base = settings.subtitlesOffset ?? 0;
+        video.setSubtitlesOffset(overlayHidden ? base : Math.min(100, base + CONTROL_BAR_SUBTITLE_BUMP));
+    }, [overlayHidden, settings.subtitlesOffset]);
 
     React.useEffect(() => {
         defaultSubtitlesSelected.current = false;

--- a/src/routes/Player/Video/styles.less
+++ b/src/routes/Player/Video/styles.less
@@ -7,6 +7,7 @@
 
         * {
             font-size: inherit;
+            pointer-events: none;
         }
     }
 }


### PR DESCRIPTION
## Problem
When moving the mouse, the control bar appears at the bottom of the player and overlaps the subtitles, making them unreadable. This is especially disruptive when watching foreign language content, since the bar has a delay before hiding and context can be lost.

## Solution
When the control bar becomes visible, subtitles are shifted upward to avoid the overlap. When the bar hides, subtitles return to their original position.

Additionally, subtitle elements were set to `pointer-events: none` to prevent them from interfering with the bar's auto-hide timer.

## Changes
- `Player.js`: added effect to adjust subtitle offset based on control bar visibility
- `Video/styles.less`: added `pointer-events: none` to video children


## Proof

Dev branch:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/51c68b04-603f-476b-9b8d-2e7b55cdd019" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/479957a8-f886-47aa-b463-5971eaab26cc" />

Feat branch:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1439a5fa-cec4-4368-a0d6-c11516ee2695" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0d7b53f3-bd12-4465-bdff-82cc5ebce045" />
