### PR TITLE
fix: prevent hold-to-speed-up when menus are open

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -767,6 +767,7 @@ const Player = ({ urlParams, queryParams }) => {
     React.useLayoutEffect(() => {
         const onKeyDown = (e) => {
             if (e.code !== 'Space' || e.repeat) return;
+            if (menusOpen || nextVideoPopupOpen) return;
 
             longPress.current = false;
 
@@ -804,6 +805,7 @@ const Player = ({ urlParams, queryParams }) => {
 
         const onMouseDownHold = (e) => {
             if (e.button !== 0) return; // left mouse button only
+            if (menusOpen || nextVideoPopupOpen) return;
             if (controlBarRef.current && controlBarRef.current.contains(e.target)) return;
 
             longPress.current = false;


### PR DESCRIPTION
## Summary
- Guard mouse hold and spacebar hold speed-up with `menusOpen || nextVideoPopupOpen` check
- Prevents the 2x speed-up from triggering when interacting with subtitles, audio, speed, statistics, or options menus

Closes Stremio/stremio-bugs#2440