### PR TITLE
fix: move streams loading indicator below list to prevent layout shift

### DIFF
--- a/src/routes/MetaDetails/StreamsList/StreamsList.js
+++ b/src/routes/MetaDetails/StreamsList/StreamsList.js
@@ -170,17 +170,6 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
                             </div>
                             :
                             <React.Fragment>
-                                {
-                                    countLoadingAddons > 0 ?
-                                        <div className={styles['addons-loading-container']}>
-                                            <div className={styles['addons-loading']}>
-                                                {countLoadingAddons} {t('MOBILE_ADDONS_LOADING')}
-                                            </div>
-                                            <span className={styles['addons-loading-bar']}></span>
-                                        </div>
-                                        :
-                                        null
-                                }
                                 <div className={styles['streams-container']} ref={streamsContainerRef}>
                                     {filteredStreams.map((stream, index) => (
                                         <Stream
@@ -206,6 +195,17 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
                                             null
                                     }
                                 </div>
+                                {
+                                    countLoadingAddons > 0 ?
+                                        <div className={styles['addons-loading-container']}>
+                                            <div className={styles['addons-loading']}>
+                                                {countLoadingAddons} {t('MOBILE_ADDONS_LOADING')}
+                                            </div>
+                                            <span className={styles['addons-loading-bar']}></span>
+                                        </div>
+                                        :
+                                        null
+                                }
                             </React.Fragment>
             }
         </div>

--- a/src/routes/MetaDetails/StreamsList/styles.less
+++ b/src/routes/MetaDetails/StreamsList/styles.less
@@ -198,5 +198,13 @@
                 background-color: transparent;
             }
         }
+
+        .addons-loading-container {
+            position: sticky;
+            bottom: 0;
+            margin: 0;
+            padding: 1em;
+            background-color: var(--primary-background-color);
+        }
     }
 }

--- a/src/routes/MetaDetails/StreamsList/styles.less
+++ b/src/routes/MetaDetails/StreamsList/styles.less
@@ -50,7 +50,7 @@
         display: flex;
         z-index: 1;
         overflow: visible;
-        margin: 2em 1em 0 1em;
+        margin: 2em;
         gap: 1em;
         flex-direction: column;
         justify-content: center;

--- a/src/routes/MetaDetails/StreamsList/styles.less
+++ b/src/routes/MetaDetails/StreamsList/styles.less
@@ -55,6 +55,7 @@
         flex-direction: column;
         justify-content: center;
         align-items: center;
+        border-radius: var(--border-radius) var(--border-radius) 0 0;
 
         .addons-loading {
             color: var(--primary-foreground-color);


### PR DESCRIPTION
## Summary
- Moved the "addons are still loading" indicator from above the streams list to below it
- The indicator remains outside the scrollable container so it's always visible
- When it disappears, the stream items above stay in place — no more layout shift causing mis-clicks

Closes Stremio/stremio-bugs#2187
