### PR TITLE
Fix crash when no extra option is selected in Discover

### DIFF
--- a/src/routes/Discover/useSelectableInputs.js
+++ b/src/routes/Discover/useSelectableInputs.js
@@ -54,13 +54,13 @@ const mapSelectableInputs = (discover, t) => {
                     value
                 })
             })),
-            value: JSON.stringify({
+            value: selectedExtra ? JSON.stringify({
                 href: selectedExtra.deepLinks.discover,
                 value: selectedExtra.value,
-            }),
+            }) : undefined,
             title: options.some(({ selected, value }) => selected && value === null) ?
                 () => t.string(name.toUpperCase())
-                : t.string(selectedExtra.value),
+                : selectedExtra ? t.string(selectedExtra.value) : () => t.string(name.toUpperCase()),
             onSelect: (value) => {
                 const { href } = JSON.parse(value);
                 window.location = href;


### PR DESCRIPTION
## Summary
- Guard against `selectedExtra` being `undefined` in `useSelectableInputs.js` when `options.find()` returns no match
- Prevents `TypeError: Cannot read properties of undefined (reading 'deepLinks')` that crashes the Discover page

Closes Stremio/stremio-bugs#961

## Test plan
- [ ] Navigate to Discover page with various catalog/addon configurations
- [ ] Verify extra selects render correctly when an option is selected
- [ ] Verify no crash when no extra option has `selected: true`
