### PR TITLE
Player: Remember selected subtitles language 

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -31,6 +31,7 @@ const { default: Indicator } = require('./Indicator/Indicator');
 
 const findTrackByLang = (tracks, lang) => tracks.find((track) => track.lang === lang || langs.where('1', track.lang)?.[2] === lang);
 const findTrackById = (tracks, id) => tracks.find((track) => track.id === id);
+const getTrackLang = (tracks, id) => id !== null ? findTrackById(tracks, id)?.lang : null;
 
 const Player = ({ urlParams, queryParams }) => {
     const { t } = useTranslation();
@@ -241,9 +242,10 @@ const Player = ({ urlParams, queryParams }) => {
             subtitleTrack: {
                 id,
                 embedded: true,
+                lang: getTrackLang(video.state.subtitlesTracks, id),
             },
         });
-    }, [streamStateChanged]);
+    }, [streamStateChanged, video.state.subtitlesTracks]);
 
     const onExtraSubtitlesTrackSelected = React.useCallback((id) => {
         video.setExtraSubtitlesTrack(id);
@@ -251,9 +253,10 @@ const Player = ({ urlParams, queryParams }) => {
             subtitleTrack: {
                 id,
                 embedded: false,
+                lang: getTrackLang(video.state.extraSubtitlesTracks, id),
             },
         });
-    }, [streamStateChanged]);
+    }, [streamStateChanged, video.state.extraSubtitlesTracks]);
 
     const onAudioTrackSelected = React.useCallback((id) => {
         video.setAudioTrack(id);
@@ -466,13 +469,16 @@ const Player = ({ urlParams, queryParams }) => {
             }
 
             const savedTrackId = player.streamState?.subtitleTrack?.id;
+            const savedLang = player.streamState?.subtitleTrack?.lang;
+            const fallbackLang = savedLang ?? settings.subtitlesLanguage;
+
             const subtitlesTrack = savedTrackId ?
                 findTrackById(video.state.subtitlesTracks, savedTrackId) :
-                findTrackByLang(video.state.subtitlesTracks, settings.subtitlesLanguage);
+                findTrackByLang(video.state.subtitlesTracks, fallbackLang);
 
             const extraSubtitlesTrack = savedTrackId ?
                 findTrackById(video.state.extraSubtitlesTracks, savedTrackId) :
-                findTrackByLang(video.state.extraSubtitlesTracks, settings.subtitlesLanguage);
+                findTrackByLang(video.state.extraSubtitlesTracks, fallbackLang);
 
             if (subtitlesTrack && subtitlesTrack.id) {
                 video.setSubtitlesTrack(subtitlesTrack.id);

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -31,7 +31,6 @@ const { default: Indicator } = require('./Indicator/Indicator');
 
 const findTrackByLang = (tracks, lang) => tracks.find((track) => track.lang === lang || langs.where('1', track.lang)?.[2] === lang);
 const findTrackById = (tracks, id) => tracks.find((track) => track.id === id);
-const getTrackLang = (tracks, id) => id !== null ? findTrackById(tracks, id)?.lang : null;
 
 const Player = ({ urlParams, queryParams }) => {
     const { t } = useTranslation();
@@ -236,27 +235,19 @@ const Player = ({ urlParams, queryParams }) => {
 
     }, []);
 
-    const onSubtitlesTrackSelected = React.useCallback((id) => {
-        video.setSubtitlesTrack(id);
+    const onSubtitlesTrackSelected = React.useCallback((track) => {
+        video.setSubtitlesTrack(track?.id ?? null);
         streamStateChanged({
-            subtitleTrack: {
-                id,
-                embedded: true,
-                lang: getTrackLang(video.state.subtitlesTracks, id),
-            },
+            subtitleTrack: track ? { id: track.id, embedded: true, lang: track.lang } : null,
         });
-    }, [streamStateChanged, video.state.subtitlesTracks]);
+    }, [streamStateChanged]);
 
-    const onExtraSubtitlesTrackSelected = React.useCallback((id) => {
-        video.setExtraSubtitlesTrack(id);
+    const onExtraSubtitlesTrackSelected = React.useCallback((track) => {
+        video.setExtraSubtitlesTrack(track?.id ?? null);
         streamStateChanged({
-            subtitleTrack: {
-                id,
-                embedded: false,
-                lang: getTrackLang(video.state.extraSubtitlesTracks, id),
-            },
+            subtitleTrack: track ? { id: track.id, embedded: false, lang: track.lang } : null,
         });
-    }, [streamStateChanged, video.state.extraSubtitlesTracks]);
+    }, [streamStateChanged]);
 
     const onAudioTrackSelected = React.useCallback((id) => {
         video.setAudioTrack(id);
@@ -470,15 +461,16 @@ const Player = ({ urlParams, queryParams }) => {
 
             const savedTrackId = player.streamState?.subtitleTrack?.id;
             const savedLang = player.streamState?.subtitleTrack?.lang;
-            const fallbackLang = savedLang ?? settings.subtitlesLanguage;
 
-            const subtitlesTrack = savedTrackId ?
-                findTrackById(video.state.subtitlesTracks, savedTrackId) :
-                findTrackByLang(video.state.subtitlesTracks, fallbackLang);
+            const subtitlesTrack =
+                savedTrackId ? findTrackById(video.state.subtitlesTracks, savedTrackId) :
+                    savedLang ? findTrackByLang(video.state.subtitlesTracks, savedLang) :
+                        findTrackByLang(video.state.subtitlesTracks, settings.subtitlesLanguage);
 
-            const extraSubtitlesTrack = savedTrackId ?
-                findTrackById(video.state.extraSubtitlesTracks, savedTrackId) :
-                findTrackByLang(video.state.extraSubtitlesTracks, fallbackLang);
+            const extraSubtitlesTrack =
+                savedTrackId ? findTrackById(video.state.extraSubtitlesTracks, savedTrackId) :
+                    savedLang ? findTrackByLang(video.state.extraSubtitlesTracks, savedLang) :
+                        findTrackByLang(video.state.extraSubtitlesTracks, settings.subtitlesLanguage);
 
             if (subtitlesTrack && subtitlesTrack.id) {
                 video.setSubtitlesTrack(subtitlesTrack.id);

--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -80,25 +80,26 @@ const SubtitlesMenu = React.memo((props) => {
             }
         } else if (track.embedded) {
             if (typeof props.onSubtitlesTrackSelected === 'function') {
-                props.onSubtitlesTrackSelected(track.id);
+                props.onSubtitlesTrackSelected(track);
             }
         } else {
             if (typeof props.onExtraSubtitlesTrackSelected === 'function') {
-                props.onExtraSubtitlesTrackSelected(track.id);
+                props.onExtraSubtitlesTrackSelected(track);
             }
         }
     }, [props.subtitlesTracks, props.extraSubtitlesTracks, props.onSubtitlesTrackSelected, props.onExtraSubtitlesTrackSelected]);
     const subtitlesTrackOnClick = React.useCallback((event) => {
-        if (event.currentTarget.dataset.embedded === 'true') {
+        const track = subtitlesTracksForLanguage.find((t) => t.id === event.currentTarget.dataset.id) ?? null;
+        if (track?.embedded) {
             if (typeof props.onSubtitlesTrackSelected === 'function') {
-                props.onSubtitlesTrackSelected(event.currentTarget.dataset.id);
+                props.onSubtitlesTrackSelected(track);
             }
         } else {
             if (typeof props.onExtraSubtitlesTrackSelected === 'function') {
-                props.onExtraSubtitlesTrackSelected(event.currentTarget.dataset.id);
+                props.onExtraSubtitlesTrackSelected(track);
             }
         }
-    }, [props.onSubtitlesTrackSelected, props.onExtraSubtitlesTrackSelected]);
+    }, [subtitlesTracksForLanguage, props.onSubtitlesTrackSelected, props.onExtraSubtitlesTrackSelected]);
     const onSubtitlesDelayChanged = React.useCallback((value) => {
         if (typeof props.selectedExtraSubtitlesTrackId === 'string') {
             if (props.extraSubtitlesDelay !== null && !isNaN(props.extraSubtitlesDelay)) {
@@ -175,7 +176,7 @@ const SubtitlesMenu = React.memo((props) => {
                     subtitlesTracksForLanguage.length > 0 ?
                         <div className={styles['variants-list']}>
                             {subtitlesTracksForLanguage.map((track, index) => (
-                                <Button key={index} title={track.label} className={classnames(styles['variant-option'], { 'selected': props.selectedSubtitlesTrackId === track.id || props.selectedExtraSubtitlesTrackId === track.id })} data-id={track.id} data-origin={track.origin} data-embedded={track.embedded} onClick={subtitlesTrackOnClick}>
+                                <Button key={index} title={track.label} className={classnames(styles['variant-option'], { 'selected': props.selectedSubtitlesTrackId === track.id || props.selectedExtraSubtitlesTrackId === track.id })} data-id={track.id} data-origin={track.origin} onClick={subtitlesTrackOnClick}>
                                     <div className={styles['info']}>
                                         <div className={styles['variant-label']}>
                                             {


### PR DESCRIPTION
Follow-up on #1178  based on feedback from @tymmesyde                                                                                            

Instead of persisting the subtitle language by updating the user's default settings (which would overwrite their configured preference), this implementation follows the suggestion to store the language within the existing streamState mechanism alongside the track ID.

When a subtitle track is selected, its language is now saved in streamState.subtitleTrack.lang. The auto-selection logic then uses this saved language as a fallback when the track ID doesn't match (e.g. next episode in a binge group), before falling back to the user's default subtitlesLanguage setting.

This way the subtitle language is persisted across episodes in the same binge group without modifying the user's configured default. 