### PR TITLE
feat: support line breaks in addon names to match TV app behavior

### DIFF
--- a/src/routes/MetaDetails/StreamsList/Stream/styles.less
+++ b/src/routes/MetaDetails/StreamsList/Stream/styles.less
@@ -60,6 +60,7 @@
             width: 7rem;
             font-size: 1.1rem;
             text-align: left;
+            white-space: pre-wrap;
             color: var(--primary-foreground-color);
         }
 


### PR DESCRIPTION
## The Problem

There is currently a visual inconsistency between Stremio Web and the TV (Bigscreen) app regarding how addon names are rendered. While the TV app correctly respects newline characters (\n) in the addon.name field (often used to organize metadata or versioning), the Web version collapses these characters into a single space.

## The Solution
I have updated the .addon-name class in the CSS/LESS files to use `white-space: pre-wrap;`.

**Why pre-wrap?**
Newline Support: It ensures that \n characters are rendered as actual line breaks, matching the TV app's behavior.

**Layout Safety:** Unlike white-space: pre;, pre-wrap will still wrap long strings that exceed the 7rem container width, preventing text from overflowing into other UI elements.

## Changes

Before:
<img width="493" height="101" alt="image" src="https://github.com/user-attachments/assets/33f7aa5d-f00e-4ead-b94b-8f2d2f123a8e" />
After: 
<img width="485" height="102" alt="image" src="https://github.com/user-attachments/assets/a886876c-2e02-4c72-9b41-4debed930991" />

