### PR TITLE
Discover: Correctly inifinite load results from addons when requested

### DIFF
--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -30,21 +30,30 @@ const Discover = ({ urlParams, queryParams }) => {
 
     const metasContainerRef = React.useRef();
     const metaPreviewRef = React.useRef();
+    const prevItemsCountRef = React.useRef(0);
 
     React.useEffect(() => {
         if (discover.catalog?.content.type === 'Loading') {
             metasContainerRef.current.scrollTop = 0;
+            prevItemsCountRef.current = 0;
         }
     }, [discover.catalog]);
     React.useEffect(() => {
         if (hasNextPage && metasContainerRef.current) {
-            const containerHeight = metasContainerRef.current.scrollHeight;
-            const viewportHeight = metasContainerRef.current.clientHeight;
-            if (containerHeight <= viewportHeight + SCROLL_TO_BOTTOM_THRESHOLD) {
-                loadNextPage();
+            const currentItemsCount = discover.catalog?.content.type === 'Ready'
+                ? discover.catalog.content.content.length
+                : 0;
+            const hasNewItems = currentItemsCount > prevItemsCountRef.current;
+            prevItemsCountRef.current = currentItemsCount;
+            if (hasNewItems) {
+                const containerHeight = metasContainerRef.current.scrollHeight;
+                const viewportHeight = metasContainerRef.current.clientHeight;
+                if (containerHeight <= viewportHeight + SCROLL_TO_BOTTOM_THRESHOLD) {
+                    loadNextPage();
+                }
             }
         }
-    }, [hasNextPage, loadNextPage]);
+    }, [hasNextPage, loadNextPage, discover.catalog]);
     const addToLibrary = React.useCallback(() => {
         if (selectedMetaItem === null) {
             return;


### PR DESCRIPTION
## Problem

When a catalog addon returns fewer results than `PAGE_SIZE` (100), the auto-fill viewport logic in Discover repeatedly calls `loadNextPage()` because the content never fills the viewport height. This creates an infinite loop of requests to addons even when no more data exists.

Reported in #1144.

## Root Cause

The `useEffect` at lines 39-47 checks if `containerHeight <= viewportHeight + SCROLL_TO_BOTTOM_THRESHOLD` and calls `loadNextPage()` — but never tracks whether the last fetch actually returned new items. When a small catalog can't fill the viewport, it keeps firing.

## Fix

Track the previous item count via a ref (`prevItemsCountRef`). Only trigger auto-fill when new items were actually added since the last check. Reset the counter when the catalog enters `Loading` state (i.e., a new catalog is selected).

This preserves the intended behavior — auto-loading pages until the viewport is filled — while stopping the loop when no new data comes back.