### PR TITLE
bump: react-focus-lock 2.13.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-focus-lock": "2.13.2",
+        "react-focus-lock": "2.13.7",
         "react-i18next": "^15.1.3",
         "react-is": "18.3.1",
         "spatial-navigation-polyfill": "github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-focus-lock:
-        specifier: 2.13.2
-        version: 2.13.2(@types/react@18.3.24)(react@18.3.1)
+        specifier: 2.13.7
+        version: 2.13.7(@types/react@18.3.24)(react@18.3.1)
       react-i18next:
         specifier: ^15.1.3
         version: 15.7.4(i18next@24.2.3(typescript@5.9.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
@@ -3780,11 +3780,11 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-focus-lock@2.13.2:
-    resolution: {integrity: sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==}
+  react-focus-lock@2.13.7:
+    resolution: {integrity: sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -8970,7 +8970,7 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-focus-lock@2.13.2(@types/react@18.3.24)(react@18.3.1):
+  react-focus-lock@2.13.7(@types/react@18.3.24)(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.26.0
       focus-lock: 1.3.6


### PR DESCRIPTION
## Summary

Part of Phase 1.5 step 2 (patch/minor dep bumps) of the modernization plan.

| Package | Old | New |
|---|---|---|
| react-focus-lock | 2.13.2 | 2.13.7 |

Patch release. React 18 peer unchanged.

## Test plan
- [x] `pnpm install`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] **Manual browser smoke test: open any modal (Settings shortcuts, addon details) and verify focus trap still works.** Deferred — Phase 1 test infrastructure not yet landed.