### PR TITLE
bump: use-long-press 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "spatial-navigation-polyfill": "github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6",
         "stremio-translations": "github:Stremio/stremio-translations#90ea718c18750a0e9cd6824b0ef7c512a41cb90b",
         "url": "0.11.4",
-        "use-long-press": "^3.2.0"
+        "use-long-press": "^3.3.0"
     },
     "devDependencies": {
         "@babel/core": "7.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         specifier: 0.11.4
         version: 0.11.4
       use-long-press:
-        specifier: ^3.2.0
+        specifier: ^3.3.0
         version: 3.3.0(react@18.3.1)
     devDependencies:
       '@babel/core':


### PR DESCRIPTION
## Summary

Part of Phase 1.5 step 2 (patch/minor dep bumps) of the modernization plan.

| Package | Old | New |
|---|---|---|
| use-long-press | ^3.2.0 | ^3.3.0 |

Minor release. React 18 peer unchanged.

## Test plan
- [x] `pnpm install`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] **Manual browser smoke test: long-press a library item to open context menu.** Deferred — Phase 1 test infrastructure not yet landed.