### PR TITLE
fix: add phone-specific grid breakpoints for library view

### DIFF
--- a/src/routes/Library/styles.less
+++ b/src/routes/Library/styles.less
@@ -200,3 +200,23 @@
         }
     }
 }
+
+@media @phone-portrait {
+    .library-container {
+        .library-content {
+            .meta-items-container {
+                grid-template-columns: repeat(3, 1fr);
+            }
+        }
+    }
+}
+
+@media @phone-landscape {
+    .library-container {
+        .library-content {
+            .meta-items-container {
+                grid-template-columns: repeat(4, 1fr);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

On high-resolution phones like the Pixel 9 Pro XL, the library grid shows 6 columns (tablet layout) instead of 3 because the existing breakpoints only use raw `@minimum`/`@xxsmall`/`@small` thresholds which don't account for phone viewports with custom display scaling.

The Pixel 9 Pro XL with default scaling has a viewport that lands in the `@small` breakpoint range (≤1300px → 6 columns), but the screen is physically phone-sized and should show 3 columns.

## Fix

Add `@phone-portrait` and `@phone-landscape` media query overrides to `src/routes/Library/styles.less`:

- **Portrait phones** (max-width: 500px, max-height: 1000px): 3 columns
- **Landscape phones** (max-width: 1000px, max-height: 500px): 4 columns

These use the existing `@phone-portrait` and `@phone-landscape` breakpoints from `screen-sizes.less` which are already defined but weren't applied to the Library grid.

## Why not just change `@minimum`?

The existing breakpoint variables are shared across many routes. Changing them could have unintended side effects. Using the phone-specific media queries is more targeted and only affects actual phone-sized viewports.

Ref: Stremio/stremio-bugs#2515