### PR TITLE
fix(discover): stop infinite loadNextPage loop when catalog can't fill viewport

### DIFF
--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -30,21 +30,38 @@ const Discover = ({ urlParams, queryParams }) => {
 
     const metasContainerRef = React.useRef();
     const metaPreviewRef = React.useRef();
+    const prevItemsCountRef = React.useRef(0);
+    const stallCountRef = React.useRef(0);
+    const MAX_STALLS = 2;
 
     React.useEffect(() => {
         if (discover.catalog?.content.type === 'Loading') {
             metasContainerRef.current.scrollTop = 0;
+            prevItemsCountRef.current = 0;
+            stallCountRef.current = 0;
         }
     }, [discover.catalog]);
     React.useEffect(() => {
         if (hasNextPage && metasContainerRef.current) {
+            const currentItemsCount = discover.catalog?.content.type === 'Ready'
+                ? discover.catalog.content.content.length
+                : 0;
+            if (currentItemsCount > prevItemsCountRef.current) {
+                stallCountRef.current = 0;
+            } else if (currentItemsCount > 0) {
+                stallCountRef.current += 1;
+            }
+            prevItemsCountRef.current = currentItemsCount;
+            if (stallCountRef.current >= MAX_STALLS) {
+                return;
+            }
             const containerHeight = metasContainerRef.current.scrollHeight;
             const viewportHeight = metasContainerRef.current.clientHeight;
             if (containerHeight <= viewportHeight + SCROLL_TO_BOTTOM_THRESHOLD) {
                 loadNextPage();
             }
         }
-    }, [hasNextPage, loadNextPage]);
+    }, [hasNextPage, loadNextPage, discover.catalog]);
     const addToLibrary = React.useCallback(() => {
         if (selectedMetaItem === null) {
             return;


### PR DESCRIPTION
## Problem

When a catalog addon returns fewer results than `PAGE_SIZE` (100), the auto-fill viewport logic in Discover repeatedly calls `loadNextPage()` because the content never fills the viewport height. This creates an infinite loop of requests to addons even when no more data exists.

Reported in #1144. Previous fix attempt in #1201 was too aggressive — it blocked loading entirely when items didn't change, which caused missed page loads during async state transitions.

## Root Cause

The `useEffect` at lines 39-47 checks if `containerHeight <= viewportHeight + SCROLL_TO_BOTTOM_THRESHOLD` and calls `loadNextPage()` — but never tracks whether the last fetch actually returned new items. When a small catalog can't fill the viewport, it keeps firing.

## Fix

Track item count and count consecutive "stalls" (effect runs where no new items were added). After `MAX_STALLS` (2) consecutive stalls, stop auto-filling:

- **Stall counter resets** when new items are loaded or a new catalog is selected
- **MAX_STALLS = 2** allows one retry after a stall, handling the Loading→Ready race condition that caused the regression in #1201
- Scroll-triggered loading (the `InfiniteScrollList` handler) is unaffected — this only gates the viewport-fill auto-load

This is more permissive than #1201's approach, which used a strict `hasNewItems` gate that could miss page loads during async state transitions.

## Changes

- `src/routes/Discover/Discover.js` — add `prevItemsCountRef`, `stallCountRef`, stall-count logic

Fixes #1144
Supersedes #1201

cc @kKaskak — this addresses the regression you found in #1201 where next pages sometimes didn't load. The stall-count approach allows retries before giving up instead of blocking immediately.