### PR TITLE
Dev: Fix correct Lithuanian ISO 639-2 code from 'ltu' to 'lit'

### DIFF
--- a/src/common/interfaceLanguages.json
+++ b/src/common/interfaceLanguages.json
@@ -101,7 +101,7 @@
     },
     {
         "name": "Lietuvių",
-        "codes": ["lt-LT", "ltu"]
+        "codes": ["lt-LT", "lit"]
     },
     {
         "name": "македонски јазик",


### PR DESCRIPTION
Fix incorrect ISO 639-2 code for Lithuanian in `src/common/interfaceLanguages.json`.

`ltu` → `lit` (the correct ISO 639-2/B code for Lithuanian).

Fixes #1169