### PR TITLE
Details: Fix respect PWA safe area 

### DIFF
--- a/src/routes/MetaDetails/styles.less
+++ b/src/routes/MetaDetails/styles.less
@@ -140,6 +140,7 @@
         .metadetails-content {
             display: block;
             overflow-y: auto;
+            padding-top: calc(var(--top-overlay-size) + var(--safe-area-inset-top));
 
             .spacing {
                 display: none;


### PR DESCRIPTION
## What changed

This updates the mobile `MetaDetails` layout to respect the top safe area inset in PWA mode.

The content container now includes `var(--safe-area-inset-top)` in its top padding, which prevents the meta title/description area from overlapping the device status bar when opening series details directly in the selected episode/details state.

## Why it changed

On mobile PWAs, especially in standalone mode on devices with a top status bar inset, the `MetaDetails` content could render too close to the top edge.

This was most noticeable when opening a series with a pre-selected episode, where the details/season state could place text underneath the status bar.

## How it was tested

- Tested locally in mobile PWA mode
- Verified access through local network on iPhone
- Confirmed the header background still covers the top area while the content starts below the safe area

<table>
  <tr>
    <td align="center"><strong>Before</strong></td>
    <td align="center"><strong>After</strong></td>
  </tr>
  <tr>
    <td>
      <img width="300" height="650" alt="Before" src="https://github.com/user-attachments/assets/8b99a396-50aa-4904-8c0a-6f78ac77775f" />
    </td>
    <td>
      <img width="300" height="650" alt="After" src="https://github.com/user-attachments/assets/eb4bb462-1044-406a-b33a-2ba702531b51" />
    </td>
  </tr>
</table>
