### PR TITLE
feat: add playback segment support (intro & credits)

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -16,6 +16,11 @@ const VolumeChangeIndicator = require('./VolumeChangeIndicator');
 const Error = require('./Error');
 const ControlBar = require('./ControlBar');
 const NextVideoPopup = require('./NextVideoPopup');
+const SegmentActionOverlay = require('./SegmentActionOverlay');
+const {
+    normalizePlaybackSegments,
+    findActivePlaybackSegment,
+} = require('./playbackSegments');
 const StatisticsMenu = require('./StatisticsMenu');
 const OptionsMenu = require('./OptionsMenu');
 const SubtitlesMenu = require('./SubtitlesMenu');
@@ -77,9 +82,28 @@ const Player = ({ urlParams, queryParams }) => {
     const [nextVideoPopupOpen, openNextVideoPopup, closeNextVideoPopup] = useBinaryState(false);
     const [sideDrawerOpen, , closeSideDrawer, toggleSideDrawer] = useBinaryState(false);
 
+    const normalizedPlaybackSegments = React.useMemo(() => {
+        return normalizePlaybackSegments(
+            player.selected !== null ? player.selected.stream : null,
+        );
+    }, [player.selected]);
+
+    const activePlaybackSegment = React.useMemo(() => {
+        if (video.state.time === null) {
+            return null;
+        }
+        return findActivePlaybackSegment(
+            video.state.time,
+            normalizedPlaybackSegments,
+        );
+    }, [video.state.time, normalizedPlaybackSegments]);
+
+    const skipIntroOverlayOpen =
+        activePlaybackSegment !== null && activePlaybackSegment.type === 'intro';
+
     const menusOpen = React.useMemo(() => {
-        return optionsMenuOpen || subtitlesMenuOpen || audioMenuOpen || speedMenuOpen || statisticsMenuOpen || sideDrawerOpen || nextVideoPopupOpen;
-    }, [optionsMenuOpen, subtitlesMenuOpen, audioMenuOpen, speedMenuOpen, statisticsMenuOpen, sideDrawerOpen, nextVideoPopupOpen]);
+        return optionsMenuOpen || subtitlesMenuOpen || audioMenuOpen || speedMenuOpen || statisticsMenuOpen || sideDrawerOpen || nextVideoPopupOpen || skipIntroOverlayOpen;
+    }, [optionsMenuOpen, subtitlesMenuOpen, audioMenuOpen, speedMenuOpen, statisticsMenuOpen, sideDrawerOpen, nextVideoPopupOpen, skipIntroOverlayOpen]);
 
     const closeMenus = React.useCallback(() => {
         closeOptionsMenu();
@@ -95,6 +119,8 @@ const Player = ({ urlParams, queryParams }) => {
     }, [immersed, casting, video.state.paused, menusOpen]);
 
     const nextVideoPopupDismissed = React.useRef(false);
+    const creditsEarlyPopupTimerRef = React.useRef(null);
+    const wasInCreditsSegmentRef = React.useRef(false);
     const defaultSubtitlesSelected = React.useRef(false);
     const lastSubtitleTrack = React.useRef(null);
     const defaultAudioTrackSelected = React.useRef(false);
@@ -234,6 +260,12 @@ const Player = ({ urlParams, queryParams }) => {
         video.setTime(time);
         seek(time, video.state.duration, video.state.manifest?.name);
     }, [video.state.duration, video.state.manifest]);
+
+    const onSkipIntroRequested = React.useCallback(() => {
+        if (activePlaybackSegment !== null && activePlaybackSegment.type === 'intro') {
+            onSeekRequested(activePlaybackSegment.end);
+        }
+    }, [activePlaybackSegment, onSeekRequested]);
 
     const onPlaybackSpeedChanged = React.useCallback((rate, skipUpdate) => {
         video.setPlaybackSpeed(rate);
@@ -529,13 +561,6 @@ const Player = ({ urlParams, queryParams }) => {
     }, [video.state.videoParams]);
 
     React.useEffect(() => {
-        if (player.nextVideo !== null && !nextVideoPopupDismissed.current) {
-            if (video.state.time !== null && video.state.duration !== null && video.state.time < video.state.duration && (video.state.duration - video.state.time) <= settings.nextVideoNotificationDuration) {
-                openNextVideoPopup();
-            } else {
-                closeNextVideoPopup();
-            }
-        }
         if (player.nextVideo) {
             // This is a workaround for the fact that when we call onEnded nextVideo from the player is already set to null since core unloads the stream
             // we explicitly set it to a global variable so we can access it in the onEnded function
@@ -544,7 +569,94 @@ const Player = ({ urlParams, queryParams }) => {
         } else {
             window.playerNextVideo = null;
         }
-    }, [player.nextVideo, video.state.time, video.state.duration]);
+
+        if (player.nextVideo === null || nextVideoPopupDismissed.current) {
+            if (creditsEarlyPopupTimerRef.current !== null) {
+                clearTimeout(creditsEarlyPopupTimerRef.current);
+                creditsEarlyPopupTimerRef.current = null;
+            }
+            closeNextVideoPopup();
+            return;
+        }
+
+        const time = video.state.time;
+        const duration = video.state.duration;
+        if (time === null || duration === null || time >= duration) {
+            if (creditsEarlyPopupTimerRef.current !== null) {
+                clearTimeout(creditsEarlyPopupTimerRef.current);
+                creditsEarlyPopupTimerRef.current = null;
+            }
+            closeNextVideoPopup();
+            return;
+        }
+
+        const inCreditsSegment =
+            activePlaybackSegment !== null && activePlaybackSegment.type === 'credits';
+        const inIntroSegment =
+            activePlaybackSegment !== null && activePlaybackSegment.type === 'intro';
+        const nearEndOfVideo =
+            duration - time <= settings.nextVideoNotificationDuration;
+        const shouldShowNextVideoPopup =
+            !inIntroSegment && (inCreditsSegment || nearEndOfVideo);
+
+        if (!shouldShowNextVideoPopup) {
+            if (creditsEarlyPopupTimerRef.current !== null) {
+                clearTimeout(creditsEarlyPopupTimerRef.current);
+                creditsEarlyPopupTimerRef.current = null;
+            }
+            closeNextVideoPopup();
+            return;
+        }
+
+        if (inCreditsSegment) {
+            if (nextVideoPopupOpen) {
+                if (creditsEarlyPopupTimerRef.current !== null) {
+                    clearTimeout(creditsEarlyPopupTimerRef.current);
+                    creditsEarlyPopupTimerRef.current = null;
+                }
+                return;
+            }
+            if (creditsEarlyPopupTimerRef.current === null) {
+                creditsEarlyPopupTimerRef.current = setTimeout(() => {
+                    creditsEarlyPopupTimerRef.current = null;
+                    openNextVideoPopup();
+                }, 120);
+            }
+        } else {
+            if (creditsEarlyPopupTimerRef.current !== null) {
+                clearTimeout(creditsEarlyPopupTimerRef.current);
+                creditsEarlyPopupTimerRef.current = null;
+            }
+            openNextVideoPopup();
+        }
+    }, [
+        player.nextVideo,
+        video.state.time,
+        video.state.duration,
+        activePlaybackSegment,
+        settings.nextVideoNotificationDuration,
+        nextVideoPopupOpen,
+        openNextVideoPopup,
+        closeNextVideoPopup,
+    ]);
+
+    React.useEffect(() => {
+        const inCreditsNow =
+            activePlaybackSegment !== null && activePlaybackSegment.type === 'credits';
+        if (inCreditsNow && !wasInCreditsSegmentRef.current) {
+            nextVideoPopupDismissed.current = false;
+        }
+        wasInCreditsSegmentRef.current = inCreditsNow;
+    }, [activePlaybackSegment]);
+
+    React.useEffect(() => {
+        return () => {
+            if (creditsEarlyPopupTimerRef.current !== null) {
+                clearTimeout(creditsEarlyPopupTimerRef.current);
+                creditsEarlyPopupTimerRef.current = null;
+            }
+        };
+    }, []);
 
     // Auto subtitles track selection
     React.useEffect(() => {
@@ -628,6 +740,11 @@ const Player = ({ urlParams, queryParams }) => {
         defaultAudioTrackSelected.current = false;
         lastSubtitleTrack.current = null;
         nextVideoPopupDismissed.current = false;
+        wasInCreditsSegmentRef.current = false;
+        if (creditsEarlyPopupTimerRef.current !== null) {
+            clearTimeout(creditsEarlyPopupTimerRef.current);
+            creditsEarlyPopupTimerRef.current = null;
+        }
         playingOnExternalDevice.current = false;
         // we need a timeout here to make sure that previous page unloads and the new one loads
         // avoiding race conditions and flickering
@@ -1098,6 +1215,16 @@ const Player = ({ urlParams, queryParams }) => {
                 videoState={video.state}
                 disabled={subtitlesMenuOpen}
             />
+            {
+                skipIntroOverlayOpen ?
+                    <SegmentActionOverlay
+                        className={classnames(styles['layer'], styles['skip-segment-layer'])}
+                        label={t('PLAYER_SKIP_INTRO')}
+                        onAction={onSkipIntroRequested}
+                    />
+                    :
+                    null
+            }
             {
                 nextVideoPopupOpen ?
                     <NextVideoPopup

--- a/src/routes/Player/SegmentActionOverlay/SegmentActionOverlay.js
+++ b/src/routes/Player/SegmentActionOverlay/SegmentActionOverlay.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+const React = require('react');
+const PropTypes = require('prop-types');
+const classnames = require('classnames');
+const { default: Icon } = require('@stremio/stremio-icons/react');
+const { Button } = require('stremio/components');
+const styles = require('./styles');
+
+const SegmentActionOverlay = ({ className, label, onAction }) => {
+    const onClick = React.useCallback(() => {
+        if (typeof onAction === 'function') {
+            onAction();
+        }
+    }, [onAction]);
+
+    return (
+        <div className={classnames(className, styles['segment-action-overlay'])}>
+            <Button className={styles['action-button']} onClick={onClick}>
+                <Icon className={styles['icon']} name={'next'} />
+                <span className={styles['label']}>{label}</span>
+            </Button>
+        </div>
+    );
+};
+
+SegmentActionOverlay.propTypes = {
+    className: PropTypes.string,
+    label: PropTypes.string.isRequired,
+    onAction: PropTypes.func.isRequired,
+};
+
+module.exports = SegmentActionOverlay;

--- a/src/routes/Player/SegmentActionOverlay/index.js
+++ b/src/routes/Player/SegmentActionOverlay/index.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+const SegmentActionOverlay = require('./SegmentActionOverlay');
+
+module.exports = SegmentActionOverlay;

--- a/src/routes/Player/SegmentActionOverlay/styles.less
+++ b/src/routes/Player/SegmentActionOverlay/styles.less
@@ -1,0 +1,43 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+@import (reference) '~@stremio/stremio-colors/less/stremio-colors.less';
+
+.segment-action-overlay {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: flex-end;
+    pointer-events: none;
+
+    .action-button {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 0.75rem;
+        height: 3.5rem;
+        padding: 0 1.25rem;
+        border-radius: 1.75rem;
+        pointer-events: auto;
+        background-color: var(--primary-accent-color);
+
+        &:hover, &:focus {
+            outline: var(--focus-outline-size) solid var(--primary-accent-color);
+            background-color: transparent;
+        }
+
+        .icon {
+            flex: none;
+            width: 1.4rem;
+            height: 1.4rem;
+            color: var(--primary-foreground-color);
+        }
+
+        .label {
+            flex: none;
+            max-height: 2.4em;
+            font-size: 1.1rem;
+            font-weight: 500;
+            color: var(--primary-foreground-color);
+        }
+    }
+}

--- a/src/routes/Player/playbackSegments.js
+++ b/src/routes/Player/playbackSegments.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+/**
+ * Segment start/end in metadata are in seconds (see Stremio stream behaviorHints.segments).
+ * Player time state is in milliseconds.
+ */
+const SEC_TO_MS = 1000;
+
+const normalizePlaybackSegments = (stream) => {
+    const raw =
+        stream &&
+    stream.behaviorHints &&
+    Array.isArray(stream.behaviorHints.segments)
+            ? stream.behaviorHints.segments
+            : [];
+    return raw
+        .map((s) => ({
+            type: s.type,
+            start:
+        typeof s.start === 'number' ? Math.round(s.start * SEC_TO_MS) : NaN,
+            end: typeof s.end === 'number' ? Math.round(s.end * SEC_TO_MS) : NaN,
+        }))
+        .filter(
+            (s) =>
+                (s.type === 'intro' || s.type === 'credits') &&
+        !Number.isNaN(s.start) &&
+        !Number.isNaN(s.end) &&
+        s.start <= s.end,
+        );
+};
+
+/**
+ * Returns the active segment for the current time. Credits take priority over intro when both match.
+ */
+const findActivePlaybackSegment = (timeMs, normalizedSegments) => {
+    if (
+        typeof timeMs !== 'number' ||
+    !Number.isFinite(timeMs) ||
+    !normalizedSegments.length
+    ) {
+        return null;
+    }
+    const inCredits = normalizedSegments.find(
+        (s) => s.type === 'credits' && timeMs >= s.start && timeMs <= s.end,
+    );
+    if (inCredits) {
+        return inCredits;
+    }
+    const inIntro = normalizedSegments.find(
+        (s) => s.type === 'intro' && timeMs >= s.start && timeMs <= s.end,
+    );
+    return inIntro || null;
+};
+
+module.exports = {
+    normalizePlaybackSegments,
+    findActivePlaybackSegment,
+};

--- a/src/routes/Player/styles.less
+++ b/src/routes/Player/styles.less
@@ -134,6 +134,18 @@ html:not(.active-slider-within) {
             overflow: auto;
         }
 
+        &.skip-segment-layer {
+            top: initial;
+            left: initial;
+            right: 4rem;
+            bottom: 7.5rem;
+            max-width: calc(100% - 4rem);
+            background: transparent;
+            box-shadow: none;
+            backdrop-filter: none;
+            overflow: visible;
+        }
+
         &.side-drawer-layer {
             bottom: 0;
             right: 0;

--- a/src/types/Stream.d.ts
+++ b/src/types/Stream.d.ts
@@ -3,6 +3,11 @@ type StreamDeepLinks = {
     player: string | null,
     externalPlayer: ExternalPlayerLinks,
 };
+type PlaybackSegment = {
+    type: 'intro' | 'credits',
+    start: number,
+    end: number,
+};
 
 type Stream = {
     ytId?: string,
@@ -14,5 +19,8 @@ type Stream = {
     deepLinks: {
         player: string,
         externalPlayer: ExternalPlayerLinks,
+    },
+    behaviorHints?: BehaviorHints & {
+        segments?: PlaybackSegment[],
     },
 };

--- a/tests/playbackSegments.test.js
+++ b/tests/playbackSegments.test.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+const {
+  normalizePlaybackSegments,
+  findActivePlaybackSegment,
+} = require("../src/routes/Player/playbackSegments");
+
+describe("normalizePlaybackSegments", () => {
+  it("returns empty array when stream is missing", () => {
+    expect(normalizePlaybackSegments(null)).toEqual([]);
+  });
+
+  it("parses intro and credits in seconds to ms", () => {
+    const stream = {
+      behaviorHints: {
+        segments: [
+          { type: "intro", start: 52, end: 110 },
+          { type: "credits", start: 2400, end: 2600 },
+        ],
+      },
+    };
+    expect(normalizePlaybackSegments(stream)).toEqual([
+      { type: "intro", start: 52000, end: 110000 },
+      { type: "credits", start: 2400000, end: 2600000 },
+    ]);
+  });
+
+  it("drops invalid segments", () => {
+    const stream = {
+      behaviorHints: {
+        segments: [
+          { type: "intro", start: 10, end: 5 },
+          { type: "recap", start: 0, end: 1 },
+          { type: "intro", start: 1, end: 2 },
+        ],
+      },
+    };
+    expect(normalizePlaybackSegments(stream)).toEqual([
+      { type: "intro", start: 1000, end: 2000 },
+    ]);
+  });
+});
+
+describe("findActivePlaybackSegment", () => {
+  const segments = [
+    { type: "intro", start: 52000, end: 110000 },
+    { type: "credits", start: 2400000, end: 2600000 },
+  ];
+
+  it("returns null when time is invalid", () => {
+    expect(findActivePlaybackSegment(null, segments)).toBeNull();
+  });
+
+  it("detects intro", () => {
+    expect(findActivePlaybackSegment(60000, segments)).toEqual(segments[0]);
+  });
+
+  it("detects credits", () => {
+    expect(findActivePlaybackSegment(2500000, segments)).toEqual(segments[1]);
+  });
+
+  it("prioritizes credits over intro when both ranges match", () => {
+    const overlap = [
+      { type: "intro", start: 0, end: 100000 },
+      { type: "credits", start: 50000, end: 150000 },
+    ];
+    expect(findActivePlaybackSegment(80000, overlap)).toEqual(overlap[1]);
+  });
+});


### PR DESCRIPTION
### 🎯 Vision / Objective

This PR introduces a **generic playback segments system** in Stremio Web, enabling time-based UI interactions during video playback.

The initial implementation supports:

* **Intro segments → Skip Intro overlay**
* **Credits segments → Early Next Episode trigger window**

The goal is not to implement a feature-specific behavior, but to establish a **clean separation of responsibilities between metadata providers and the UI layer**.

---

### 🧠 Architectural Vision: Clear Separation of Concerns

This change reinforces a strict separation between:

#### 🔌 Addons (Data Providers)

* Responsible for providing **metadata per stream**
* May include optional `behaviorHints.segments`
* Can define:

  * intro ranges
  * credits ranges
  * or any future segment types
* Fully flexible: users can implement or choose their own addons / APIs

👉 Stremio does **not enforce how this data is generated**

---

#### 🖥️ Stremio Web (UI / Decision Layer)

* Responsible for:

  * interpreting segment metadata
  * deciding when to show overlays
  * handling user interactions (Skip Intro, Next Episode triggers)
* Implements UI logic only
* Does NOT assume correctness of metadata

👉 Stremio acts purely as a **rendering and orchestration layer**

---

### 📦 Data Model Introduced

```json
{
  "behaviorHints": {
    "segments": [
      { "type": "intro", "start": 52, "end": 110 },
      { "type": "credits", "start": 2400, "end": 2600 }
    ]
  }
}
```

This structure is:

* optional
* extensible
* fully addon-driven

---

### 🎬 Features Implemented

#### 1. Skip Intro (UI-driven)

* Detects active `intro` segment during playback
* Displays “Skip Intro” button
* Seeks to segment end on interaction

---

#### 2. Credits-aware Next Episode triggering

Credits segments are used as a **temporal extension of the Next Episode system**:

* When playback enters a `credits` segment:

  * Stremio Web may trigger **Next Episode overlay earlier than end-of-video**
* If no next episode exists:

  * no additional UI is forced (keeps existing behavior)

👉 This enhances continuity without changing core playback logic.

---

### 🔄 Key Principle: Stremio is not responsible for metadata correctness

This design ensures:

* Stremio does NOT validate or enforce segment correctness
* Any discrepancies (wrong timestamps, missing data, incorrect detection) are **fully delegated to the addon or external provider**
* UI behaves strictly based on provided data

👉 This avoids coupling Stremio to:

* external APIs (e.g. IntroDB-like services)
* community-generated metadata quality
* provider-specific inconsistencies

---

### 🌐 Extensibility Benefit

This architecture enables users and developers to:

* plug in **any metadata provider they want**
* experiment with different segment detection systems
* build custom APIs without modifying Stremio Web
* iterate independently on:

  * intro detection
  * credit detection
  * chapter systems

👉 Stremio becomes a **neutral execution layer**, not a data authority.

---

### ⚙️ Behavior Rules

* No segment data → default behavior unchanged
* Invalid segments → safely ignored
* Overlapping segments → credits takes priority over intro
* Seeking behavior → recalculates active segment state
* Next Episode logic remains unchanged except for credits early trigger window

---

### 🚀 Impact

This PR establishes a foundation for:

* chapter-like playback experiences
* richer binge-watching flows
* future segment types (recap, chapters, etc.)
* full decoupling between metadata sources and UI behavior

---

### 💡 Summary

Stremio Web now supports a **provider-agnostic playback segment system**, where:

* Addons define *what exists*
* Stremio Web defines *how it is presented*

This ensures maximum flexibility, extensibility, and independence from any single metadata source or detection strategy.

---

The translations PR is available here:
[https://github.com/Stremio/stremio-translations/pull/1041](https://github.com/Stremio/stremio-translations/pull/1041)
