### PR TITLE
Player: Improve handling of macOS media controls

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -255,6 +255,12 @@ const Player = ({ urlParams, queryParams }) => {
         }
     }, [player.nextVideo, handleNextVideoNavigation, profile.settings]);
 
+    const onPreviousTrackRequested = React.useCallback(() => {
+        if (video.state.time !== null && video.state.time > 5000) {
+            onSeekRequested(0);
+        }
+    }, [video.state.time, onSeekRequested]);
+
     const onVideoClick = React.useCallback(() => {
         if (video.state.paused !== null && !longPress.current) {
             if (video.state.paused) {
@@ -534,13 +540,21 @@ const Player = ({ urlParams, queryParams }) => {
         }
     }, [settings.pauseOnMinimize, shell.windowClosed, shell.windowHidden]);
 
-    useMediaSession(video.state, player, onPlayRequested, onPauseRequested, onNextVideoRequested);
+    useMediaSession(video.state, player, onPlayRequested, onPauseRequested, onNextVideoRequested, onPreviousTrackRequested);
 
     React.useEffect(() => {
         const onMediaKey = (action) => {
             switch (action) {
                 case 'play-pause':
-                    video.state.paused ? onPlayRequested() : onPauseRequested();
+                    if (video.state.paused !== null) {
+                        video.state.paused ? onPlayRequested() : onPauseRequested();
+                    }
+                    break;
+                case 'play':
+                    onPlayRequested();
+                    break;
+                case 'pause':
+                    onPauseRequested();
                     break;
                 case 'next-track':
                     if (player.nextVideo !== null) {
@@ -549,15 +563,13 @@ const Player = ({ urlParams, queryParams }) => {
                     }
                     break;
                 case 'previous-track':
-                    if (video.state.time !== null && video.state.time > 5000) {
-                        onSeekRequested(0);
-                    }
+                    onPreviousTrackRequested();
                     break;
             }
         };
         shell.on('media-key', onMediaKey);
         return () => shell.off('media-key', onMediaKey);
-    }, [video.state.paused, video.state.time, player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested, onSeekRequested]);
+    }, [video.state.paused, player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested, onPreviousTrackRequested]);
 
     onShortcut('seekForward', (combo) => {
         if (video.state.time !== null) {

--- a/src/routes/Player/useMediaSession.ts
+++ b/src/routes/Player/useMediaSession.ts
@@ -6,11 +6,12 @@ const useMediaSession = (
     onPlayRequested: () => void,
     onPauseRequested: () => void,
     onNextVideoRequested: () => void,
+    onPreviousTrackRequested: () => void,
 ) => {
     useEffect(() => {
         if (!navigator.mediaSession) return;
 
-        const playbackState = !videoState.paused ? 'playing' : 'paused';
+        const playbackState = videoState.paused === null ? 'none' : videoState.paused ? 'paused' : 'playing';
         navigator.mediaSession.playbackState = playbackState;
 
         return () => {
@@ -49,9 +50,17 @@ const useMediaSession = (
         navigator.mediaSession.setActionHandler('play', onPlayRequested);
         navigator.mediaSession.setActionHandler('pause', onPauseRequested);
 
-        const nexVideoCallback = player.nextVideo ? onNextVideoRequested : null;
-        navigator.mediaSession.setActionHandler('nexttrack', nexVideoCallback);
-    }, [player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested]);
+        const nextVideoCallback = player.nextVideo ? onNextVideoRequested : null;
+        navigator.mediaSession.setActionHandler('nexttrack', nextVideoCallback);
+        navigator.mediaSession.setActionHandler('previoustrack', onPreviousTrackRequested);
+
+        return () => {
+            navigator.mediaSession.setActionHandler('play', null);
+            navigator.mediaSession.setActionHandler('pause', null);
+            navigator.mediaSession.setActionHandler('nexttrack', null);
+            navigator.mediaSession.setActionHandler('previoustrack', null);
+        };
+    }, [player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested, onPreviousTrackRequested]);
 };
 
 export default useMediaSession;


### PR DESCRIPTION
## Summary

- handle explicit shell `media-key` `play` and `pause` actions in the player
- route Media Session `previoustrack` through the same previous-track behavior as shell media keys
- keep Media Session playback state and action handlers cleaned up when the player unmounts

## Why

macOS/AirPods controls can arrive as explicit `play` or `pause` events instead of only `play-pause`. The shell handler previously ignored those explicit actions, so hardware or system media controls could fire without changing playback.

## Behavior

- `play` calls the existing player play callback
- `pause` calls the existing player pause callback
- `play-pause` toggles only when playback state is known
- `next-track` keeps advancing to the next video when available
- `previous-track` keeps seeking to the beginning after 5 seconds
- Media Session handlers are reset on cleanup

## Validation

- `pnpm lint`
- `pnpm build`

Build completes with the existing webpack asset-size/performance warnings.

## Manual macOS checks

- AirPods remove-to-pause
- AirPods stem/button play/pause
- keyboard media play/pause
- macOS Control Center play/pause
- focused and unfocused app states
