### PR TITLE
Player: Remove previous media key seeking

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -255,12 +255,6 @@ const Player = ({ urlParams, queryParams }) => {
         }
     }, [player.nextVideo, handleNextVideoNavigation, profile.settings]);
 
-    const onPreviousTrackRequested = React.useCallback(() => {
-        if (video.state.time !== null && video.state.time > 5000) {
-            onSeekRequested(0);
-        }
-    }, [video.state.time, onSeekRequested]);
-
     const onVideoClick = React.useCallback(() => {
         if (video.state.paused !== null && !longPress.current) {
             if (video.state.paused) {
@@ -540,7 +534,7 @@ const Player = ({ urlParams, queryParams }) => {
         }
     }, [settings.pauseOnMinimize, shell.windowClosed, shell.windowHidden]);
 
-    useMediaSession(video.state, player, onPlayRequested, onPauseRequested, onNextVideoRequested, onPreviousTrackRequested);
+    useMediaSession(video.state, player, onPlayRequested, onPauseRequested, onNextVideoRequested);
 
     React.useEffect(() => {
         const onMediaKey = (action) => {
@@ -562,14 +556,11 @@ const Player = ({ urlParams, queryParams }) => {
                         onNextVideoRequested();
                     }
                     break;
-                case 'previous-track':
-                    onPreviousTrackRequested();
-                    break;
             }
         };
         shell.on('media-key', onMediaKey);
         return () => shell.off('media-key', onMediaKey);
-    }, [video.state.paused, player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested, onPreviousTrackRequested]);
+    }, [video.state.paused, player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested]);
 
     onShortcut('seekForward', (combo) => {
         if (video.state.time !== null) {

--- a/src/routes/Player/useMediaSession.ts
+++ b/src/routes/Player/useMediaSession.ts
@@ -6,7 +6,6 @@ const useMediaSession = (
     onPlayRequested: () => void,
     onPauseRequested: () => void,
     onNextVideoRequested: () => void,
-    onPreviousTrackRequested: () => void,
 ) => {
     useEffect(() => {
         if (!navigator.mediaSession) return;
@@ -52,15 +51,13 @@ const useMediaSession = (
 
         const nextVideoCallback = player.nextVideo ? onNextVideoRequested : null;
         navigator.mediaSession.setActionHandler('nexttrack', nextVideoCallback);
-        navigator.mediaSession.setActionHandler('previoustrack', onPreviousTrackRequested);
 
         return () => {
             navigator.mediaSession.setActionHandler('play', null);
             navigator.mediaSession.setActionHandler('pause', null);
             navigator.mediaSession.setActionHandler('nexttrack', null);
-            navigator.mediaSession.setActionHandler('previoustrack', null);
         };
-    }, [player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested, onPreviousTrackRequested]);
+    }, [player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested]);
 };
 
 export default useMediaSession;


### PR DESCRIPTION
## Summary

- remove the shell `media-key` `previous-track` seek/restart behavior
- stop registering the Media Session `previoustrack` handler
- keep play, pause, play-pause, and next-track media controls unchanged

## Why

Follow-up to #1252 and the maintainer discussion around `previoustrack`. Since Stremio does not currently expose a proper previous-episode/player action, mapping external previous media controls to seek-to-start can be surprising for long-form video. For now, avoid seeking with media previous controls rather than exposing rewind/restart as `previoustrack`.

## Notes

This does not change in-player seek shortcuts or UI behavior. It only removes previous external media-key handling from the player shell hook and Media Session registration.

## Validation

- `pnpm lint`
- `pnpm build`

Build completes with the existing webpack asset-size/performance warnings.
