### PR TITLE
Shortcuts: Correct the Esc key shortcut label

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "react-i18next": "^15.7.4",
         "react-is": "18.3.1",
         "spatial-navigation-polyfill": "github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6",
-        "stremio-translations": "github:Stremio/stremio-translations#c2d68dc590ac7d56f0df5e69a2144ba83e0d5ef0",
+        "stremio-translations": "github:Stremio/stremio-translations#f8ef365fcc90b7904a11ad2e3ebb95c0c9b16163",
         "url": "0.11.4",
         "use-long-press": "^3.3.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6
         version: https://codeload.github.com/Stremio/spatial-navigation/tar.gz/64871b1422466f5f45d24ebc8bbd315b2ebab6a6
       stremio-translations:
-        specifier: github:Stremio/stremio-translations#c2d68dc590ac7d56f0df5e69a2144ba83e0d5ef0
-        version: https://codeload.github.com/Stremio/stremio-translations/tar.gz/c2d68dc590ac7d56f0df5e69a2144ba83e0d5ef0
+        specifier: github:Stremio/stremio-translations#f8ef365fcc90b7904a11ad2e3ebb95c0c9b16163
+        version: https://codeload.github.com/Stremio/stremio-translations/tar.gz/f8ef365fcc90b7904a11ad2e3ebb95c0c9b16163
       url:
         specifier: 0.11.4
         version: 0.11.4
@@ -4421,8 +4421,8 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
-  stremio-translations@https://codeload.github.com/Stremio/stremio-translations/tar.gz/c2d68dc590ac7d56f0df5e69a2144ba83e0d5ef0:
-    resolution: {tarball: https://codeload.github.com/Stremio/stremio-translations/tar.gz/c2d68dc590ac7d56f0df5e69a2144ba83e0d5ef0}
+  stremio-translations@https://codeload.github.com/Stremio/stremio-translations/tar.gz/f8ef365fcc90b7904a11ad2e3ebb95c0c9b16163:
+    resolution: {tarball: https://codeload.github.com/Stremio/stremio-translations/tar.gz/f8ef365fcc90b7904a11ad2e3ebb95c0c9b16163}
     version: 1.52.0
 
   string-length@4.0.2:
@@ -10000,7 +10000,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  stremio-translations@https://codeload.github.com/Stremio/stremio-translations/tar.gz/c2d68dc590ac7d56f0df5e69a2144ba83e0d5ef0: {}
+  stremio-translations@https://codeload.github.com/Stremio/stremio-translations/tar.gz/f8ef365fcc90b7904a11ad2e3ebb95c0c9b16163: {}
 
   string-length@4.0.2:
     dependencies:


### PR DESCRIPTION
labeling was misleading: Escape was shown as player “Exit / Go Back”, but depending on the setting it may actually mean “exit fullscreen” and intentionally not go back.

label changed to "Exit Fullscreen / Go Back"
