### PR TITLE
Skip-segment CTA, early next-video trigger, and UX polish

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -11,7 +11,7 @@ const { useCore } = require('stremio/core');
 const { useServices, useGamepad } = require('stremio/services');
 const { useContentGamepadNavigation } = require('stremio/services/GamepadNavigation');
 const { useSettings, useProfile, useFullscreen, useBinaryState, useToast, useStreamingServer, withCoreSuspender, useShell, usePlatform, onShortcut } = require('stremio/common');
-const { HorizontalNavBar, Transition, ContextMenu } = require('stremio/components');
+const { HorizontalNavBar, Transition, ContextMenu, Button } = require('stremio/components');
 const BufferingLoader = require('./BufferingLoader');
 const VolumeChangeIndicator = require('./VolumeChangeIndicator');
 const Error = require('./Error');
@@ -35,6 +35,11 @@ const { default: useMediaSession } = require('./useMediaSession');
 
 const findTrackByLang = (tracks, lang) => tracks.find((track) => track.lang === lang || langs.where('1', track.lang)?.[2] === lang);
 const findTrackById = (tracks, id) => tracks.find((track) => track.id === id);
+const formatSegmentName = (segment) => String(segment || '')
+    .split(/[_-]/)
+    .filter(Boolean)
+    .map((word) => word[0] ? `${word[0].toUpperCase()}${word.slice(1)}` : word)
+    .join(' ');
 
 const GAMEPAD_HANDLER_ID = 'player';
 
@@ -217,6 +222,45 @@ const Player = ({ urlParams, queryParams }) => {
         video.setTime(time);
         seek(time, video.state.duration, video.state.manifest?.name);
     }, [video.state.duration, video.state.manifest]);
+    const activeSkippableSegment = React.useMemo(() => {
+        if (typeof video.state.time !== 'number') {
+            return null;
+        }
+
+        const segments = player.introOutro?.segments;
+        if (!Array.isArray(segments)) {
+            return null;
+        }
+
+        return segments.find((segment) =>
+            typeof segment?.from === 'number' &&
+            typeof segment?.to === 'number' &&
+            typeof segment?.segment === 'string' &&
+            video.state.time >= segment.from &&
+            video.state.time <= segment.to
+        ) || null;
+    }, [player.introOutro, video.state.time]);
+    const activeSkippableSegmentLabel = React.useMemo(() => {
+        return activeSkippableSegment ? formatSegmentName(activeSkippableSegment.segment) : null;
+    }, [activeSkippableSegment]);
+    const skipSegmentButtonLabel = React.useMemo(() => {
+        if (!activeSkippableSegmentLabel) {
+            return null;
+        }
+
+        const translated = t('STREMIO_TV_PLAYER_BUTTON_SKIP_CHAPTER');
+        if (typeof translated === 'string' && translated !== 'STREMIO_TV_PLAYER_BUTTON_SKIP_CHAPTER') {
+            return translated.replace('${1}', activeSkippableSegmentLabel);
+        }
+
+        return `Skip ${activeSkippableSegmentLabel}`;
+    }, [activeSkippableSegmentLabel]);
+    const onSkipSegmentRequested = React.useCallback(() => {
+        if (activeSkippableSegment !== null) {
+            setSeeking(true);
+            onSeekRequested(activeSkippableSegment.to);
+        }
+    }, [activeSkippableSegment, onSeekRequested]);
 
     const onPlaybackSpeedChanged = React.useCallback((rate, skipUpdate) => {
         video.setPlaybackSpeed(rate);
@@ -441,7 +485,15 @@ const Player = ({ urlParams, queryParams }) => {
 
     React.useEffect(() => {
         if (player.nextVideo !== null && !nextVideoPopupDismissed.current) {
-            if (video.state.time !== null && video.state.duration !== null && video.state.time < video.state.duration && (video.state.duration - video.state.time) <= settings.nextVideoNotificationDuration) {
+            const enteredOutro = typeof player.introOutro?.outro === 'number' &&
+                typeof video.state.time === 'number' &&
+                video.state.time >= player.introOutro.outro;
+            const withinDefaultWindow = video.state.time !== null &&
+                video.state.duration !== null &&
+                video.state.time < video.state.duration &&
+                (video.state.duration - video.state.time) <= settings.nextVideoNotificationDuration;
+
+            if (enteredOutro || withinDefaultWindow) {
                 openNextVideoPopup();
             } else {
                 closeNextVideoPopup();
@@ -455,7 +507,7 @@ const Player = ({ urlParams, queryParams }) => {
         } else {
             window.playerNextVideo = null;
         }
-    }, [player.nextVideo, video.state.time, video.state.duration]);
+    }, [player.nextVideo, player.introOutro, video.state.time, video.state.duration]);
 
     // Auto audio track selection
     React.useEffect(() => {
@@ -895,6 +947,16 @@ const Player = ({ urlParams, queryParams }) => {
                 onMouseOver={onBarMouseMove}
                 onTouchEnd={onContainerMouseLeave}
             />
+            {
+                activeSkippableSegment !== null && !menusOpen && skipSegmentButtonLabel !== null ?
+                    <div className={classnames(styles['layer'], styles['skip-segment-layer'])}>
+                        <Button className={styles['skip-segment-button']} onClick={onSkipSegmentRequested}>
+                            {skipSegmentButtonLabel}
+                        </Button>
+                    </div>
+                    :
+                    null
+            }
             <Indicator
                 className={classnames(styles['layer'], styles['indicator-layer'])}
                 videoState={video.state}

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -133,6 +133,8 @@ const Player = ({ urlParams, queryParams }) => {
     const pressTimer = React.useRef(null);
     const longPress = React.useRef(false);
     const controlBarRef = React.useRef(null);
+    const skipSegmentButtonRef = React.useRef(null);
+    const skipSegmentVisibleRef = React.useRef(false);
 
     const HOLD_DELAY = 400;
 
@@ -261,6 +263,7 @@ const Player = ({ urlParams, queryParams }) => {
             onSeekRequested(activeSkippableSegment.to);
         }
     }, [activeSkippableSegment, onSeekRequested]);
+    const skipSegmentVisible = activeSkippableSegment !== null && !menusOpen && skipSegmentButtonLabel !== null;
 
     const onPlaybackSpeedChanged = React.useCallback((rate, skipUpdate) => {
         video.setPlaybackSpeed(rate);
@@ -587,6 +590,14 @@ const Player = ({ urlParams, queryParams }) => {
             onPauseRequested();
         }
     }, [settings.pauseOnMinimize, shell.windowClosed, shell.windowHidden]);
+
+    React.useEffect(() => {
+        if (skipSegmentVisible && !skipSegmentVisibleRef.current) {
+            skipSegmentButtonRef.current?.focus();
+        }
+
+        skipSegmentVisibleRef.current = skipSegmentVisible;
+    }, [skipSegmentVisible]);
 
     useMediaSession(video.state, player, onPlayRequested, onPauseRequested, onNextVideoRequested);
 
@@ -948,9 +959,13 @@ const Player = ({ urlParams, queryParams }) => {
                 onTouchEnd={onContainerMouseLeave}
             />
             {
-                activeSkippableSegment !== null && !menusOpen && skipSegmentButtonLabel !== null ?
+                skipSegmentVisible ?
                     <div className={classnames(styles['layer'], styles['skip-segment-layer'])}>
-                        <Button className={styles['skip-segment-button']} onClick={onSkipSegmentRequested}>
+                        <Button
+                            ref={skipSegmentButtonRef}
+                            className={styles['skip-segment-button']}
+                            onClick={onSkipSegmentRequested}
+                        >
                             {skipSegmentButtonLabel}
                         </Button>
                     </div>

--- a/src/routes/Player/styles.less
+++ b/src/routes/Player/styles.less
@@ -119,6 +119,28 @@ html:not(.active-slider-within) {
             bottom: 10rem;
         }
 
+        &.skip-segment-layer {
+            top: initial;
+            left: initial;
+            right: 4rem;
+            bottom: 11rem;
+            pointer-events: none;
+            display: flex;
+            justify-content: flex-end;
+            align-items: flex-end;
+
+            .skip-segment-button {
+                pointer-events: auto;
+                border-radius: 4rem;
+                padding: 1rem 1.6rem;
+                font-weight: 700;
+                color: var(--primary-foreground-color);
+                background-color: var(--modal-background-color);
+                box-shadow: 0 1.35rem 2.7rem @color-background-dark5-40,
+                    0 1.1rem 0.85rem @color-background-dark5-20;
+            }
+        }
+
         &.menu-layer {
             top: initial;
             left: initial;
@@ -148,6 +170,10 @@ html:not(.active-slider-within) {
         .layer {
             &.side-drawer-button-layer {
                 right: -2rem;
+            }
+
+            &.skip-segment-layer {
+                right: 2rem;
             }
         }
     }

--- a/src/routes/Player/styles.less
+++ b/src/routes/Player/styles.less
@@ -135,9 +135,13 @@ html:not(.active-slider-within) {
                 padding: 1rem 1.6rem;
                 font-weight: 700;
                 color: var(--primary-foreground-color);
-                background-color: var(--modal-background-color);
-                box-shadow: 0 1.35rem 2.7rem @color-background-dark5-40,
-                    0 1.1rem 0.85rem @color-background-dark5-20;
+                background-color: var(--primary-accent-color);
+                transition: background-color 120ms ease-in;
+
+                &:hover, &:focus {
+                    outline: var(--focus-outline-size) solid var(--primary-accent-color);
+                    background-color: transparent;
+                }
             }
         }
 


### PR DESCRIPTION
**Description** 
Shows a floating "Skip {segment}" CTA when playback is inside a validated segment; clicking seeks to the segment end. Triggers the next-video prompt early when entering an outro segment while retaining the existing near-end fallback. Reuses existing i18n key. This PR implements the UI changes for https://github.com/Stremio/stremio-core/pull/979.

**Screenshots**
| Skip Intro | Skip Recap |
|--------|--------|
| <img width="960" height="600" alt="skip-intro" src="https://github.com/user-attachments/assets/199687ef-407c-43c6-ba91-1f60f29c6d4b" /> | <img width="960" height="600" alt="skip-recap" src="https://github.com/user-attachments/assets/825557d2-0ca9-4be0-a6db-f0ca6c8fa357" /> | 




**Files** 
- src/routes/Player/Player.js
- src/routes/Player/styles.less

**Testing** 
`cd stremio-web && pnpm install && pnpm build && pnpm test (lint/i18n)`

Manually verify in dev server using an episode with IntroDB data:
- Intro only: `curl "https://api.introdb.app/segments?imdb_id=tt2356777&season=1&episode=1"` (True Detective)
- Intro & Outro: `curl "https://api.introdb.app/segments?imdb_id=tt0944947&season=1&episode=1"` (Game of Thrones)
- Recap & Outro: `curl "https://api.introdb.app/segments?imdb_id=tt6741278&season=2&episode=2"` (Invincible)