### PR TITLE
MetaDetails: Videos list scroll to top on season change

### DIFF
--- a/src/routes/MetaDetails/VideosList/VideosList.js
+++ b/src/routes/MetaDetails/VideosList/VideosList.js
@@ -11,10 +11,11 @@ const SeasonsBar = require('./SeasonsBar');
 const { default: EpisodePicker } = require('../EpisodePicker');
 const styles = require('./styles');
 
+let savedScrollTop = 0;
+
 const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, selectedVideoId, toggleNotifications }) => {
     const core = useCore();
     const profile = useProfile();
-
     const showNotificationsToggle = React.useMemo(() => {
         return metaItem?.content?.content?.inLibrary && metaItem?.content?.content?.videos?.length;
     }, [metaItem]);
@@ -72,17 +73,35 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
     }, [videosForSeason]);
 
     const videosContainerRef = React.useRef(null);
+    const isMountedRef = React.useRef(false);
+
+    const saveScrollPosition = React.useCallback(() => {
+        savedScrollTop = videosContainerRef.current?.scrollTop ?? 0;
+    }, []);
+
+    // Restore scroll on mount (before paint), consume immediately
+    React.useLayoutEffect(() => {
+        if (savedScrollTop > 0 && videosContainerRef.current) {
+            videosContainerRef.current.scrollTop = savedScrollTop;
+            savedScrollTop = 0;
+        }
+    }, []);
+
+    // Scroll to top when the season changes (skip on initial mount to respect restored scroll position)
+    React.useEffect(() => {
+        if (!isMountedRef.current) {
+            isMountedRef.current = true;
+            return;
+        }
+        if (videosContainerRef.current) {
+            videosContainerRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+    }, [selectedSeason]);
 
     const [search, setSearch] = React.useState('');
     const searchInputOnChange = React.useCallback((event) => {
         setSearch(event.currentTarget.value);
     }, []);
-
-    React.useEffect(() => {
-        if (videosContainerRef.current) {
-            videosContainerRef.current.scrollTo({ top: 0, behavior: 'smooth' });
-        }
-    }, [selectedSeason]);
 
     const onMarkVideoAsWatched = (video, watched) => {
         core.transport.dispatch({
@@ -173,24 +192,25 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
                                                 );
                                         })
                                         .map((video, index) => (
-                                            <Video
-                                                key={index}
-                                                id={video.id}
-                                                title={video.title}
-                                                thumbnail={video.thumbnail}
-                                                season={video.season}
-                                                episode={video.episode}
-                                                released={video.released}
-                                                upcoming={video.upcoming}
-                                                watched={video.watched}
-                                                progress={video.progress}
-                                                deepLinks={video.deepLinks}
-                                                scheduled={video.scheduled}
-                                                seasonWatched={seasonWatched}
-                                                selected={video.id === selectedVideoId}
-                                                onMarkVideoAsWatched={onMarkVideoAsWatched}
-                                                onMarkSeasonAsWatched={onMarkSeasonAsWatched}
-                                            />
+                                            <div key={index} onClick={saveScrollPosition}>
+                                                <Video
+                                                    id={video.id}
+                                                    title={video.title}
+                                                    thumbnail={video.thumbnail}
+                                                    season={video.season}
+                                                    episode={video.episode}
+                                                    released={video.released}
+                                                    upcoming={video.upcoming}
+                                                    watched={video.watched}
+                                                    progress={video.progress}
+                                                    deepLinks={video.deepLinks}
+                                                    scheduled={video.scheduled}
+                                                    seasonWatched={seasonWatched}
+                                                    selected={video.id === selectedVideoId}
+                                                    onMarkVideoAsWatched={onMarkVideoAsWatched}
+                                                    onMarkSeasonAsWatched={onMarkSeasonAsWatched}
+                                                />
+                                            </div>
                                         ))
                                 }
                             </div>

--- a/src/routes/MetaDetails/VideosList/VideosList.js
+++ b/src/routes/MetaDetails/VideosList/VideosList.js
@@ -93,7 +93,8 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
             isMountedRef.current = true;
             return;
         }
-        if (videosContainerRef.current) {
+        const hasSelectedVideo = videosForSeason.some((v) => v.id === selectedVideoId);
+        if (!hasSelectedVideo && videosContainerRef.current) {
             videosContainerRef.current.scrollTo({ top: 0, behavior: 'smooth' });
         }
     }, [selectedSeason]);

--- a/src/routes/MetaDetails/VideosList/VideosList.js
+++ b/src/routes/MetaDetails/VideosList/VideosList.js
@@ -71,10 +71,18 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
         return videosForSeason.every((video) => video.watched);
     }, [videosForSeason]);
 
+    const videosContainerRef = React.useRef(null);
+
     const [search, setSearch] = React.useState('');
     const searchInputOnChange = React.useCallback((event) => {
         setSearch(event.currentTarget.value);
     }, []);
+
+    React.useEffect(() => {
+        if (videosContainerRef.current) {
+            videosContainerRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+    }, [selectedSeason]);
 
     const onMarkVideoAsWatched = (video, watched) => {
         core.transport.dispatch({
@@ -154,7 +162,7 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
                                 value={search}
                                 onChange={searchInputOnChange}
                             />
-                            <div className={styles['videos-container']}>
+                            <div ref={videosContainerRef} className={styles['videos-container']}>
                                 {
                                     videosForSeason
                                         .filter((video) => {


### PR DESCRIPTION
This PR handles the following:

**Season changed scroll:** Scroll the episodes list to the top when a different season is selected.
**Back navigation scroll:** Preserve the episodes list scroll position when navigating back from the streams list.