### PR TITLE
Player: Fix audio tracks default selection issue

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -467,9 +467,8 @@ const Player = ({ urlParams, queryParams }) => {
     React.useEffect(() => {
         if (!defaultAudioTrackSelected.current) {
             const savedTrackId = player.streamState?.audioTrack?.id;
-            const audioTrack = savedTrackId ?
-                findTrackById(video.state.audioTracks, savedTrackId) :
-                findTrackByLang(video.state.audioTracks, settings.audioLanguage);
+            const savedTrack = savedTrackId ? findTrackById(video.state.audioTracks, savedTrackId) : null;
+            const audioTrack = savedTrack ?? findTrackByLang(video.state.audioTracks, settings.audioLanguage);
 
             if (audioTrack && audioTrack.id) {
                 video.setAudioTrack(audioTrack.id);


### PR DESCRIPTION
Root cause (regression from commit 39741d137 — "feat: remember selected tracks on player"): the auto-select effect used a ternary that took either the saved track or
   the language match. When streamState.audioTrack.id is set but doesn't resolve to any current audio track (stale ID from a previous session — e.g. different stream
  source / encoding for the same episode), findTrackById returns undefined, and settings.audioLanguage is never consulted.

  Behavior:
  - saved ID resolves → use saved track
  - saved ID is stale → fall back to settings.audioLanguage 
  - no saved ID → language match (unchanged)