### PR TITLE
Player: Fix media session airpods take off bug

### DIFF
--- a/src/routes/Player/useMediaSession.ts
+++ b/src/routes/Player/useMediaSession.ts
@@ -77,8 +77,8 @@ const useMediaSession = (
     // Callbacks
     useEffect(() => {
         if (navigator.mediaSession) {
-            navigator.mediaSession.setActionHandler('play', onPlayRequested);
-            navigator.mediaSession.setActionHandler('pause', onPauseRequested);
+            navigator.mediaSession.setActionHandler('play', videoState.paused === true ? onPlayRequested : null);
+            navigator.mediaSession.setActionHandler('pause', videoState.paused === false ? onPauseRequested : null);
         }
 
         const nexVideoCallback = player.nextVideo ? onNextVideoRequested : null;
@@ -96,9 +96,9 @@ const useMediaSession = (
             navigator.mediaSession.setActionHandler('play', null);
             navigator.mediaSession.setActionHandler('pause', null);
             navigator.mediaSession.setActionHandler('nexttrack', null);
-            shell.on('media.status', onMediaStatus);
+            shell.off('media.status', onMediaStatus);
         };
-    }, [player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested]);
+    }, [videoState.paused, player.nextVideo, onPlayRequested, onPauseRequested, onNextVideoRequested]);
 };
 
 export default useMediaSession;


### PR DESCRIPTION
Fixes stremio-bugs#2554 — playback no longer auto-resumes when an audio output device (AirPods, Bluetooth headphones) disconnects while the video is paused.

- correct cleanup to shell off 