### PR TITLE
fix: handle malformed route params without crashing

### DIFF
--- a/src/common/safeDecodeURIComponent.js
+++ b/src/common/safeDecodeURIComponent.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const safeDecodeURIComponent = (value) => {
+    try {
+        return decodeURIComponent(value);
+    } catch (_) {
+        return value;
+    }
+};
+
+module.exports = safeDecodeURIComponent;

--- a/src/router/Router/urlParamsForPath.js
+++ b/src/router/Router/urlParamsForPath.js
@@ -1,10 +1,12 @@
 // Copyright (C) 2017-2023 Smart code 203358507
 
+const safeDecodeURIComponent = require('../../common/safeDecodeURIComponent');
+
 const urlParamsForPath = (routeConfig, path) => {
     const matches = path.match(routeConfig.regexp);
     return routeConfig.urlParamsNames.reduce((urlParams, name, index) => {
         if (Array.isArray(matches) && typeof matches[index + 1] === 'string') {
-            urlParams[name] = decodeURIComponent(matches[index + 1]);
+            urlParams[name] = safeDecodeURIComponent(matches[index + 1]);
         } else {
             urlParams[name] = null;
         }

--- a/src/routes/MetaDetails/EpisodePicker/EpisodePicker.tsx
+++ b/src/routes/MetaDetails/EpisodePicker/EpisodePicker.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useMemo, useState, ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, NumberInput } from 'stremio/components';
+import safeDecodeURIComponent from 'stremio/common/safeDecodeURIComponent';
 import styles from './EpisodePicker.less';
 
 type Props = {
@@ -19,7 +20,7 @@ const EpisodePicker = ({ className, onSubmit }: Props) => {
         if (splitPath[splitPath.length - 1] === '') {
             splitPath.pop();
         }
-        const videoId = decodeURIComponent(splitPath[splitPath.length - 1]);
+        const videoId = safeDecodeURIComponent(splitPath[splitPath.length - 1]);
         const [, pathSeason, pathEpisode] = videoId ? videoId.split(':') : [];
         return {
             initialSeason: parseInt(pathSeason) || 0,

--- a/tests/urlParamsForPath.spec.js
+++ b/tests/urlParamsForPath.spec.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const routesRegexp = require('../src/common/routesRegexp');
+const urlParamsForPath = require('../src/router/Router/urlParamsForPath');
+
+describe('urlParamsForPath', () => {
+    it('decodes route parameters', () => {
+        expect(urlParamsForPath(routesRegexp.metadetails, '/metadetails/movie/tt%3A123%2Fvideo')).toEqual({
+            path: '/metadetails/movie/tt%3A123%2Fvideo',
+            type: 'movie',
+            id: 'tt:123/video',
+            videoId: null
+        });
+    });
+
+    it('keeps malformed route parameters raw instead of throwing', () => {
+        expect(() => urlParamsForPath(routesRegexp.metadetails, '/metadetails/movie/%E0%A4%A')).not.toThrow();
+        expect(urlParamsForPath(routesRegexp.metadetails, '/metadetails/movie/%E0%A4%A')).toEqual({
+            path: '/metadetails/movie/%E0%A4%A',
+            type: 'movie',
+            id: '%E0%A4%A',
+            videoId: null
+        });
+    });
+});


### PR DESCRIPTION
Fixes #1288.

## What changed
- Added a safe route-parameter decoder that preserves malformed percent-encoded values instead of throwing.
- Updated router parameter parsing and the meta details episode picker to use the safe decoder.
- Added Jest coverage for normal decoded route params and malformed route params.

## Why
Malformed external or manually entered hash routes such as `#/metadetails/movie/%E0%A4%A` currently throw `URIError: URI malformed` during route parsing, which can break navigation before the app can render a route or fallback.

## Validation
- `node -e "const routes=require('./src/common/routesRegexp'); const urlParams=require('./src/router/Router/urlParamsForPath'); console.log(JSON.stringify(urlParams(routes.metadetails, '/metadetails/movie/%E0%A4%A')));"`
- `pnpm jest tests/urlParamsForPath.spec.js --runInBand`
- `pnpm lint`
- `pnpm build`
- `pnpm jest --runInBand`