### PR TITLE
feat: accept Cmd+/ for shortcuts on Apple platforms

### DIFF
--- a/src/common/Platform/device.ts
+++ b/src/common/Platform/device.ts
@@ -32,8 +32,10 @@ const os = bowser.getOSName().toLowerCase();
 
 const name = isVisionOS ? 'visionos' : isIOS ? 'ios' : os || 'unknown';
 const isMobile = ['ios', 'android'].includes(name);
+const isApple = ['macos', 'ios', 'visionos'].includes(name);
 
 export {
     name,
     isMobile,
+    isApple,
 };

--- a/src/common/Shortcuts/Shortcuts.tsx
+++ b/src/common/Shortcuts/Shortcuts.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef } from 'react';
+import { isApple } from 'stremio/common/Platform/device';
 import shortcuts from './shortcuts.json';
 
 const SHORTCUTS = shortcuts.map(({ shortcuts }) => shortcuts).flat();
@@ -44,10 +45,14 @@ const ShortcutsProvider = ({ children, onShortcut }: Props) => {
         }
 
         SHORTCUTS.forEach(({ name, combos }) => combos.forEach((keys) => {
-            const modifers = (keys.includes('Ctrl') === ctrlKey)
+            const expectsCtrl = keys.includes('Ctrl');
+            const acceptsMetaModifier = isApple && expectsCtrl && keys.includes('/');
+            const ctrlModifier = expectsCtrl ? (ctrlKey || (acceptsMetaModifier && metaKey)) : (!ctrlKey && !metaKey);
+
+            const modifers = ctrlModifier
                 && (keys.includes('Shift') === shiftKey)
                 && !altKey
-                && !metaKey;
+                && (acceptsMetaModifier || !metaKey);
 
             if (modifers && (keys.includes(code) || keys.includes(key.toUpperCase()))) {
                 const combo = combos.indexOf(keys);

--- a/src/components/ShortcutsGroup/Combos/Keys/Keys.tsx
+++ b/src/components/ShortcutsGroup/Combos/Keys/Keys.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isApple } from 'stremio/common/Platform/device';
 import styles from './Keys.less';
 
 type Props = {
@@ -12,14 +13,14 @@ const Keys = ({ keys }: Props) => {
     const keyLabelMap: Record<string, string> = useMemo(() => ({
         'Shift': `⇧ ${t('SETTINGS_SHORTCUT_SHIFT')}`,
         'Space': t('SETTINGS_SHORTCUT_SPACE'),
-        'Ctrl': t('SETTINGS_SHORTCUT_CTRL'),
+        'Ctrl': isApple && keys.includes('/') ? '⌘' : t('SETTINGS_SHORTCUT_CTRL'),
         'Escape': t('SETTINGS_SHORTCUT_ESC'),
         'Backspace': t('SETTINGS_SHORTCUT_BACKSPACE'),
         'ArrowUp': '↑',
         'ArrowDown': '↓',
         'ArrowLeft': '←',
         'ArrowRight': '→',
-    }), [t]);
+    }), [keys, t]);
 
     const isRange = useMemo(() => {
         return keys.length > 1 && keys.every((key) => !Number.isNaN(parseInt(key)));


### PR DESCRIPTION
## Summary

- accept Cmd+/ as the shortcuts-modal shortcut on Apple platforms
- keep Ctrl+/ working for existing users
- show the native Cmd glyph for that shortcut in the shortcuts modal

This is scoped narrowly to Cmd+/ so other Ctrl-prefixed shortcuts keep their existing behavior and do not start intercepting browser-level shortcuts like Cmd+G. The focused-input guard is already present on current `development`, so this PR leaves that upstream behavior unchanged.

## Verification

- npm test -- --runInBand
- npm run lint
- npm run build
- Browser smoke test on https://localhost:8080/: Cmd+/ opens shortcuts; Ctrl+/ opens shortcuts; shortcuts modal shows `⌘`; Cmd+G does not open gamepad controls; Ctrl+G still opens gamepad controls; Cmd+Backspace does not trigger app history navigation