### PR TITLE
fix(Library): filter watched sort results

### DIFF
--- a/src/routes/Library/Library.js
+++ b/src/routes/Library/Library.js
@@ -54,14 +54,33 @@ const Library = ({ model, urlParams, queryParams }) => {
     const [library, loadNextPage] = useLibrary(model, urlParams, queryParams);
     const [typeSelect, sortChips, hasNextPage] = useSelectableInputs(library);
     const scrollContainerRef = React.useRef(null);
+    const watchedFilter = React.useMemo(() => {
+        switch (library.selected?.request.sort) {
+            case 'watched':
+            case 'timeswatched':
+                return true;
+            case 'notwatched':
+                return false;
+            default:
+                return null;
+        }
+    }, [library.selected]);
+    const catalog = React.useMemo(() => {
+        return watchedFilter === null ?
+            library.catalog
+            :
+            library.catalog.filter(({ watched }) => watched === watchedFilter);
+    }, [library.catalog, watchedFilter]);
+    const hasHiddenWatchedFilterItems = watchedFilter !== null && library.catalog.some(({ watched }) => watched !== watchedFilter);
+    const hasFilteredNextPage = hasNextPage && !hasHiddenWatchedFilterItems;
     const onScrollToBottom = React.useCallback(() => {
-        if (hasNextPage) {
+        if (hasFilteredNextPage) {
             loadNextPage();
         }
-    }, [hasNextPage, loadNextPage]);
+    }, [hasFilteredNextPage, loadNextPage]);
     const onScroll = useOnScrollToBottom(onScrollToBottom, SCROLL_TO_BOTTOM_TRESHOLD);
     React.useLayoutEffect(() => {
-        if (scrollContainerRef.current !== null && library.selected && library.selected.request.page === 1 && library.catalog.length !== 0) {
+        if (scrollContainerRef.current !== null && library.selected && library.selected.request.page === 1 && catalog.length !== 0) {
             scrollContainerRef.current.scrollTop = 0;
         }
     }, [profile.auth, library.selected]);
@@ -92,7 +111,7 @@ const Library = ({ model, urlParams, queryParams }) => {
                                     </div>
                                 </DelayedRenderer>
                                 :
-                                library.catalog.length === 0 ?
+                                catalog.length === 0 ?
                                     <div className={styles['message-container']}>
                                         <Image
                                             className={styles['image']}
@@ -104,7 +123,7 @@ const Library = ({ model, urlParams, queryParams }) => {
                                     :
                                     <div ref={scrollContainerRef} className={classnames(styles['meta-items-container'], 'animation-fade-in')} onScroll={onScroll}>
                                         {
-                                            library.catalog.map((libItem, index) => (
+                                            catalog.map((libItem, index) => (
                                                 <LibItem {...libItem} notifications={notifications} removable={model === 'library'} key={index} />
                                             ))
                                         }


### PR DESCRIPTION
Dear, 

I opened this MR as I believe that the Not Watched and Watched options should not be a "sort" option but rather an actual filter. I made a small change that hides the Not Watched items when clicking the filter "Watched". Viceversa, I hid the Watched items in the "Not Watched".

The rationale is that when I want to check what I have not watched yet, I do not want to see items that I have already watched.

similar concept is applied to "Most Watched" items.

## Open question
- `lastwatched` is intentionally unchanged in this PR. Should Last watched also hide not-watched items, or should it continue to show the full library ordered by last watched activity?

## Summary
- filter Library results for the Watched and Not watched sort chips so the opposite watch state is not rendered at the end
- filter the Most watched sort to watched items only, since not-watched items have no watch count
- stop requesting more pages once the loaded core-sorted catalog reaches the opposite watch-state group

Thanks for this amazing project, I hope the contribution is appreciated.

L.