### PR TITLE
Allow direct subtitle delay entry

### DIFF
--- a/src/routes/Player/SubtitlesMenu/Stepper/Stepper.less
+++ b/src/routes/Player/SubtitlesMenu/Stepper/Stepper.less
@@ -38,11 +38,44 @@
             }
         }
 
-        .value {
+        .value, .editable-value {
             flex: 1;
             font-weight: 500;
             text-align: center;
             color: var(--primary-foreground-color);
+        }
+
+        .editable-value {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            justify-content: center;
+            min-width: 0;
+            user-select: text;
+
+            .input {
+                flex: 0 1 5rem;
+                min-width: 0;
+                padding: 0;
+                border: none;
+                outline: none;
+                appearance: textfield;
+                font: inherit;
+                color: var(--primary-foreground-color);
+                text-align: right;
+                background: transparent;
+
+                &::-webkit-outer-spin-button,
+                &::-webkit-inner-spin-button {
+                    -webkit-appearance: none;
+                    margin: 0;
+                }
+            }
+
+            .unit {
+                flex: none;
+                margin-left: 0.2rem;
+            }
         }
     }
 }

--- a/src/routes/Player/SubtitlesMenu/Stepper/Stepper.tsx
+++ b/src/routes/Player/SubtitlesMenu/Stepper/Stepper.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import Icon from '@stremio/stremio-icons/react';
@@ -12,22 +12,37 @@ const clamp = (value: number, min?: number, max?: number) => {
     return maxClamped;
 };
 
+const formatNumber = (value: number | null) => {
+    if (typeof value !== 'number') {
+        return '';
+    }
+
+    return Number.isInteger(value) ?
+        value.toString()
+        :
+        value.toFixed(3).replace(/\.?0+$/, '');
+};
+
 type Props = {
     className: string,
     label: string,
-    value: number,
+    value: number | null,
     unit?: string,
     step: number,
     min?: number,
     max?: number,
     disabled?: boolean,
+    editable?: boolean,
     onChange: (value: number) => void,
 };
 
-const Stepper = ({ className, label, value, unit, step, min, max, disabled, onChange }: Props) => {
+const Stepper = ({ className, label, value, unit, step, min, max, disabled, editable, onChange }: Props) => {
     const { t } = useTranslation();
 
     const localValue = useRef(value);
+    const skipBlurCommit = useRef(false);
+    const [editing, setEditing] = useState(false);
+    const [draftValue, setDraftValue] = useState(formatNumber(value));
 
     const interval = useInterval(100);
     const timeout = useTimeout(250);
@@ -50,8 +65,76 @@ const Stepper = ({ className, label, value, unit, step, min, max, disabled, onCh
     }, [disabled, value, unit]);
 
     const updateValue = useCallback((delta: number) => {
-        onChange(clamp(localValue.current + delta, min, max));
-    }, [onChange]);
+        if (typeof localValue.current !== 'number') {
+            return;
+        }
+
+        const nextValue = clamp(localValue.current + delta, min, max);
+
+        localValue.current = nextValue;
+        onChange(nextValue);
+    }, [max, min, onChange]);
+
+    const commitDraftValue = useCallback(() => {
+        const normalizedValue = draftValue.trim().replace(',', '.');
+        const parsedValue = normalizedValue.length > 0 ? Number(normalizedValue) : Number.NaN;
+
+        setEditing(false);
+
+        if (Number.isFinite(parsedValue)) {
+            const nextValue = clamp(parsedValue, min, max);
+
+            localValue.current = nextValue;
+            setDraftValue(formatNumber(nextValue));
+            onChange(nextValue);
+        } else {
+            setDraftValue(formatNumber(value));
+        }
+    }, [draftValue, max, min, onChange, value]);
+
+    const onValueBlur = useCallback(() => {
+        if (skipBlurCommit.current) {
+            skipBlurCommit.current = false;
+            return;
+        }
+
+        commitDraftValue();
+    }, [commitDraftValue]);
+
+    const resetDraftValue = useCallback(() => {
+        setEditing(false);
+        setDraftValue(formatNumber(value));
+    }, [value]);
+
+    const onValueFocus = useCallback((event: React.FocusEvent<HTMLInputElement>) => {
+        setEditing(true);
+        event.currentTarget.select();
+    }, []);
+
+    const onValueChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+        setDraftValue(event.currentTarget.value);
+    }, []);
+
+    const onValueKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+        event.stopPropagation();
+
+        switch (event.key) {
+            case 'Enter': {
+                event.preventDefault();
+                commitDraftValue();
+                skipBlurCommit.current = true;
+                event.currentTarget.blur();
+                break;
+            }
+            case 'Escape': {
+                event.preventDefault();
+                resetDraftValue();
+                skipBlurCommit.current = true;
+                event.currentTarget.blur();
+                break;
+            }
+        }
+    }, [commitDraftValue, resetDraftValue]);
 
     const onDecrementMouseDown = useCallback(() => {
         cancel();
@@ -77,6 +160,12 @@ const Stepper = ({ className, label, value, unit, step, min, max, disabled, onCh
         localValue.current = value;
     }, [value]);
 
+    useEffect(() => {
+        if (!editing) {
+            setDraftValue(formatNumber(value));
+        }
+    }, [editing, value]);
+
     return (
         <div className={classNames(styles['stepper'], className)}>
             <div className={styles['header']}>
@@ -91,9 +180,34 @@ const Stepper = ({ className, label, value, unit, step, min, max, disabled, onCh
                 >
                     <Icon className={styles['icon']} name={'remove'} />
                 </Button>
-                <div className={styles['value']}>
-                    { valueLabel }
-                </div>
+                {
+                    editable && !disabled && typeof value === 'number' ?
+                        <div className={styles['editable-value']}>
+                            <input
+                                className={styles['input']}
+                                type={'text'}
+                                inputMode={'decimal'}
+                                aria-label={t(label)}
+                                value={draftValue}
+                                onBlur={onValueBlur}
+                                onChange={onValueChange}
+                                onFocus={onValueFocus}
+                                onKeyDown={onValueKeyDown}
+                            />
+                            {
+                                typeof unit === 'string' && unit.length > 0 ?
+                                    <span className={styles['unit']}>
+                                        { unit }
+                                    </span>
+                                    :
+                                    null
+                            }
+                        </div>
+                        :
+                        <div className={styles['value']}>
+                            { valueLabel }
+                        </div>
+                }
                 <Button
                     className={classNames(styles['button'], { 'disabled': increaseDisabled })}
                     onMouseDown={onIncrementMouseDown}

--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -215,6 +215,7 @@ const SubtitlesMenu = React.memo(React.forwardRef((props, ref) => {
                         value={props.extraSubtitlesDelay / 1000}
                         unit={'s'}
                         step={0.25}
+                        editable={true}
                         disabled={props.extraSubtitlesDelay === null}
                         onChange={onSubtitlesDelayChanged}
                     />


### PR DESCRIPTION
## Summary

This makes the subtitle delay value in the player subtitles menu directly editable while keeping the existing +/- buttons at 0.25s increments.

The motivation is a real playback case where subtitles were more than 40 seconds out of sync. With only 0.25s steps, reaching the rough offset requires too many repeated clicks before fine tuning can even start.

## Behavior

- Users can type the delay in seconds directly in the existing delay stepper.
- Enter or blur commits the typed value; Escape restores the current value.
- The +/- buttons still adjust by 0.25s for precise tuning after the rough offset is entered.
- Size and vertical position steppers remain display-only values with buttons, matching their previous behavior.
- The existing `subtitleDelay` stream state path is unchanged, so remembered subtitle timing continues to work as before.

## Validation

- `npx --yes pnpm@10.12.1 lint`
- `npx --yes pnpm@10.12.1 build`

The production build still reports the existing webpack asset/entrypoint size warnings.