### PR TITLE
fix(stremio-web): stabilize hosted streaming server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
 RUN corepack enable
+RUN corepack prepare pnpm@11.5.2 --activate
 RUN apk add --no-cache git
 
 # Meta

--- a/http_server.js
+++ b/http_server.js
@@ -2,7 +2,6 @@
 
 // Copyright (C) 2017-2023 Smart code 203358507
 
-const INDEX_CACHE = 7200;
 const ASSETS_CACHE = 2629744;
 const HTTP_PORT = 8080;
 
@@ -13,9 +12,18 @@ const build_path = path.resolve(__dirname, 'build');
 const index_path = path.join(build_path, 'index.html');
 
 express().use(express.static(build_path, {
-    setHeaders: (res, path) => {
-        if (path === index_path) res.set('cache-control', `public, max-age: ${INDEX_CACHE}`);
-        else res.set('cache-control', `public, max-age: ${ASSETS_CACHE}`);
+    setHeaders: (res, filePath) => {
+        if (
+            filePath === index_path ||
+            filePath.endsWith('.js') ||
+            filePath.endsWith('.css') ||
+            filePath.endsWith('.map') ||
+            filePath.endsWith('manifest.json')
+        ) {
+            res.set('cache-control', 'no-cache');
+        } else {
+            res.set('cache-control', `public, max-age: ${ASSETS_CACHE}`);
+        }
     }
 })).all('*', (_req, res) => {
     // TODO: better 404 page

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "version": "5.0.0-beta.37",
     "author": "Smart Code OOD",
     "private": true,
+    "packageManager": "pnpm@11.5.2",
     "license": "gpl-2.0",
     "scripts": {
         "start": "webpack serve --mode development",

--- a/src/App/SearchParamsHandler.js
+++ b/src/App/SearchParamsHandler.js
@@ -23,7 +23,7 @@ const SearchParamsHandler = () => {
     };
 
     React.useEffect(() => {
-        const { streamingServerUrl } = searchParams;
+        const { addon, streamingServerUrl } = searchParams;
 
         if (streamingServerUrl) {
             core.transport.dispatch({
@@ -48,6 +48,15 @@ const SearchParamsHandler = () => {
                 title: `Using streaming server at ${streamingServerUrl}`,
                 timeout: 4000,
             });
+        }
+
+        if (addon && !window.location.hash.replace('#', '').startsWith('/addons')) {
+            const addonParams = new URLSearchParams();
+            addonParams.set('addon', addon);
+            if (streamingServerUrl) {
+                addonParams.set('streamingServerUrl', streamingServerUrl);
+            }
+            window.location.replace(`${window.location.origin}/#/addons?${addonParams.toString()}`);
         }
     }, [searchParams]);
 

--- a/src/common/CONSTANTS.js
+++ b/src/common/CONSTANTS.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2017-2023 Smart code 203358507
 
 const CHROMECAST_RECEIVER_APP_ID = '1634F54B';
-const DEFAULT_STREAMING_SERVER_URL = 'http://127.0.0.1:11470/';
+const DEFAULT_STREAMING_SERVER_URL = 'https://stremio.wallmail.se/';
 const DEFAULT_SUBTITLES_LANGUAGE = 'eng';
 const LOCAL_SUBTITLES_LANGUAGE = 'local';
 const SUBTITLES_SIZES = [75, 100, 125, 150, 175, 200, 250];

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=0, user-scalable=no, viewport-fit=cover">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Stremio">

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 // Copyright (C) 2017-2023 Smart code 203358507
 
+require('./wallisStreamingServerRewrite');
+
 if (typeof process.env.SENTRY_DSN === 'string') {
     const Sentry = require('@sentry/browser');
     Sentry.init({ dsn: process.env.SENTRY_DSN });

--- a/src/wallis-worker.js
+++ b/src/wallis-worker.js
@@ -1,0 +1,41 @@
+require('./wallisStreamingServerRewrite');
+
+const Bridge = require('@stremio/stremio-core-web/bridge');
+const bridge = new Bridge(self, self);
+
+self.init = async ({ appVersion, shellVersion }) => {
+    // Shim kept from the upstream worker until bundled import.meta no longer needs it.
+    self.document = {
+        baseURI: self.location.href,
+    };
+    self.app_version = appVersion;
+    self.shell_version = shellVersion;
+
+    self.get_location_hash = async () => bridge.call(['location', 'hash'], []);
+    self.local_storage_get_item = async (key) => bridge.call(['localStorage', 'getItem'], [key]);
+    self.local_storage_set_item = async (key, value) => bridge.call(['localStorage', 'setItem'], [key, value]);
+    self.local_storage_remove_item = async (key) => bridge.call(['localStorage', 'removeItem'], [key]);
+
+    const {
+        default: initializeApi,
+        initialize_runtime: initializeRuntime,
+        get_state: getState,
+        get_debug_state: getDebugState,
+        dispatch,
+        analytics,
+        decode_stream: decodeStream,
+        encode_stream: encodeStream,
+    } = require('@stremio/stremio-core-web');
+
+    self.getState = getState;
+    self.getDebugState = getDebugState;
+    self.dispatch = dispatch;
+    self.analytics = analytics;
+    self.decodeStream = decodeStream;
+    self.encodeStream = encodeStream;
+
+    await initializeApi({
+        module_or_path: require('@stremio/stremio-core-web/stremio_core_web_bg.wasm'),
+    });
+    await initializeRuntime((event) => bridge.call(['onCoreEvent'], [event]));
+};

--- a/src/wallisStreamingServerRewrite.js
+++ b/src/wallisStreamingServerRewrite.js
@@ -1,0 +1,49 @@
+// Force hosted Stremio Web/Core to use the public Wallis streaming server
+// instead of the browser client's localhost.
+const STREAMING_SERVER_URL = 'https://stremio.wallmail.se';
+const LOCAL_STREAMING_SERVER_RE = /^http:\/\/(?:127\.0\.0\.1|localhost):11470(?=\/|$)/;
+
+const rewriteUrl = (url) => (
+    typeof url === 'string'
+        ? url.replace(LOCAL_STREAMING_SERVER_RE, STREAMING_SERVER_URL)
+        : url
+);
+
+const installFetchRewrite = (scope) => {
+    if (!scope || scope.__wallisStreamingServerRewriteInstalled) return;
+    scope.__wallisStreamingServerRewriteInstalled = true;
+
+    if (typeof scope.fetch === 'function') {
+        const nativeFetch = scope.fetch.bind(scope);
+        scope.fetch = (input, init) => {
+            if (typeof input === 'string') {
+                return nativeFetch(rewriteUrl(input), init);
+            }
+
+            if (typeof URL !== 'undefined' && input instanceof URL) {
+                return nativeFetch(new URL(rewriteUrl(input.href)), init);
+            }
+
+            if (typeof Request !== 'undefined' && input instanceof Request && LOCAL_STREAMING_SERVER_RE.test(input.url)) {
+                return nativeFetch(new Request(rewriteUrl(input.url), input), init);
+            }
+
+            return nativeFetch(input, init);
+        };
+    }
+
+    const XMLHttpRequestCtor = scope.XMLHttpRequest;
+    if (XMLHttpRequestCtor?.prototype?.open) {
+        const nativeOpen = XMLHttpRequestCtor.prototype.open;
+        XMLHttpRequestCtor.prototype.open = function open(method, url, ...rest) {
+            return nativeOpen.call(this, method, rewriteUrl(url), ...rest);
+        };
+    }
+};
+
+installFetchRewrite(typeof globalThis !== 'undefined' ? globalThis : undefined);
+
+module.exports = {
+    STREAMING_SERVER_URL,
+    rewriteUrl,
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,9 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const packageJson = require('./package.json');
 
-const COMMIT_HASH = execSync('git rev-parse HEAD').toString().trim();
+const SOURCE_COMMIT_HASH = execSync('git rev-parse HEAD').toString().trim();
+const BUILD_TIMESTAMP = new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+const COMMIT_HASH = process.env.WALLIS_BUILD_HASH || `${SOURCE_COMMIT_HASH}-${BUILD_TIMESTAMP}`;
 
 const THREAD_LOADER = {
     loader: 'thread-loader',
@@ -38,7 +40,7 @@ module.exports = (env, argv) => ({
     devtool: argv.mode === 'production' ? 'source-map' : 'eval-source-map',
     entry: {
         main: './src/index.js',
-        worker: './node_modules/@stremio/stremio-core-web/worker.js'
+        worker: './src/wallis-worker.js'
     },
     output: {
         path: path.join(__dirname, 'build'),


### PR DESCRIPTION
## Summary
- route hosted Stremio Web/Core localhost streaming-server calls to the Wallis hosted streaming server
- use an object-based stremio-core-web worker initialization path
- add cache busting for dirty hosted builds and modern PWA metadata
- declare pnpm 11.5.2 for reproducible Docker builds

## Verification
- `pnpm i --frozen-lockfile` passes with pnpm 11.5.2
- Docker image builds successfully
- deployed stremio-web container starts and serves the timestamped worker bundle