### PR TITLE
feat: add persistent player brightness controls and shortcuts

### DIFF
--- a/src/common/Shortcuts/shortcuts.json
+++ b/src/common/Shortcuts/shortcuts.json
@@ -60,6 +60,11 @@
                 "combos": [["ArrowUp"], ["ArrowDown"]]
             },
             {
+                "name": "brightness",
+                "label": "Brightness",
+                "combos": [["Shift", "ArrowUp"], ["Shift", "ArrowDown"]]
+            },
+            {
                 "name": "mute",
                 "label": "SETTINGS_SHORTCUT_MUTE",
                 "combos": [["M"]]

--- a/src/routes/Player/ControlBar/BrightnessSlider/BrightnessSlider.js
+++ b/src/routes/Player/ControlBar/BrightnessSlider/BrightnessSlider.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+const React = require('react');
+const PropTypes = require('prop-types');
+const classnames = require('classnames');
+const debounce = require('lodash.debounce');
+const { useRouteFocused } = require('stremio-router');
+const { Slider } = require('stremio/components');
+const styles = require('./styles');
+
+const DEFAULT_BRIGHTNESS = 100;
+
+const BrightnessSlider = ({ className, brightness, onBrightnessChangeRequested }) => {
+    const disabled = brightness === null || isNaN(brightness);
+    const routeFocused = useRouteFocused();
+    const [slidingBrightness, setSlidingBrightness] = React.useState(null);
+    const resetBrightnessDebounced = React.useCallback(debounce(() => {
+        setSlidingBrightness(null);
+    }, 100), []);
+    const onSlide = React.useCallback((nextBrightness) => {
+        resetBrightnessDebounced.cancel();
+        setSlidingBrightness(nextBrightness);
+        if (typeof onBrightnessChangeRequested === 'function') {
+            onBrightnessChangeRequested(nextBrightness);
+        }
+    }, [onBrightnessChangeRequested]);
+    const onComplete = React.useCallback((nextBrightness) => {
+        resetBrightnessDebounced();
+        setSlidingBrightness(nextBrightness);
+        if (typeof onBrightnessChangeRequested === 'function') {
+            onBrightnessChangeRequested(nextBrightness);
+        }
+    }, [onBrightnessChangeRequested]);
+    React.useLayoutEffect(() => {
+        if (!routeFocused || disabled) {
+            resetBrightnessDebounced.cancel();
+            setSlidingBrightness(null);
+        }
+    }, [routeFocused, disabled]);
+    React.useEffect(() => {
+        return () => {
+            resetBrightnessDebounced.cancel();
+        };
+    }, []);
+    return (
+        <Slider
+            className={classnames(className, styles['brightness-slider'], { 'active': slidingBrightness !== null })}
+            value={!disabled ? (slidingBrightness !== null ? slidingBrightness : brightness) : DEFAULT_BRIGHTNESS}
+            minimumValue={0}
+            maximumValue={200}
+            disabled={disabled}
+            onSlide={onSlide}
+            onComplete={onComplete}
+        />
+    );
+};
+
+BrightnessSlider.propTypes = {
+    brightness: PropTypes.number,
+    className: PropTypes.string,
+    onBrightnessChangeRequested: PropTypes.func,
+};
+
+module.exports = BrightnessSlider;

--- a/src/routes/Player/ControlBar/BrightnessSlider/index.js
+++ b/src/routes/Player/ControlBar/BrightnessSlider/index.js
@@ -1,0 +1,5 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+const BrightnessSlider = require('./BrightnessSlider');
+
+module.exports = BrightnessSlider;

--- a/src/routes/Player/ControlBar/BrightnessSlider/styles.less
+++ b/src/routes/Player/ControlBar/BrightnessSlider/styles.less
@@ -1,0 +1,46 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+@import (reference) '~@stremio/stremio-colors/less/stremio-colors.less';
+
+:import('~stremio/components/Slider/styles.less') {
+    slider-track: track;
+    slider-track-after: track-after;
+    slider-thumb: thumb;
+}
+
+.brightness-slider:not(:global(.disabled)) {
+    .slider-track {
+        background-color: var(--overlay-color);
+        opacity: 1;
+    }
+
+    .slider-track-after {
+        background-color: var(--primary-foreground-color);
+    }
+
+    .slider-thumb {
+        background-color: @color-secondaryvariant1-light4;
+        transition: transform 150ms ease;
+
+        &:after {
+            content: "";
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            border-radius: 100%;
+            box-shadow: 0 0 0 0.25rem white inset;
+        }
+    }
+
+    &:hover, &:global(.active) {
+        .slider-track-after {
+            background-color: var(--primary-foreground-color);
+        }
+
+        .slider-thumb {
+            transform: translateX(-50%) scale(1.2);
+        }
+    }
+}

--- a/src/routes/Player/ControlBar/ControlBar.js
+++ b/src/routes/Player/ControlBar/ControlBar.js
@@ -8,9 +8,11 @@ const { Button } = require('stremio/components');
 const { useServices } = require('stremio/services');
 const SeekBar = require('./SeekBar');
 const VolumeSlider = require('./VolumeSlider');
+const BrightnessSlider = require('./BrightnessSlider');
 const styles = require('./styles');
 const { useBinaryState, usePlatform } = require('stremio/common');
 const { t } = require('i18next');
+const DEFAULT_BRIGHTNESS = 100;
 
 const ControlBar = React.forwardRef(({
     className,
@@ -19,6 +21,7 @@ const ControlBar = React.forwardRef(({
     duration,
     buffered,
     volume,
+    brightness,
     muted,
     playbackSpeed,
     subtitlesTracks,
@@ -33,6 +36,7 @@ const ControlBar = React.forwardRef(({
     onMuteRequested,
     onUnmuteRequested,
     onVolumeChangeRequested,
+    onBrightnessChangeRequested,
     onSeekRequested,
     onToggleSubtitlesMenu,
     onToggleAudioMenu,
@@ -98,6 +102,11 @@ const ControlBar = React.forwardRef(({
     const onChromecastButtonClick = React.useCallback(() => {
         chromecast.transport.requestSession();
     }, []);
+    const onBrightnessButtonClick = React.useCallback(() => {
+        if (typeof onBrightnessChangeRequested === 'function') {
+            onBrightnessChangeRequested(DEFAULT_BRIGHTNESS);
+        }
+    }, [onBrightnessChangeRequested]);
     React.useEffect(() => {
         const onStateChanged = () => {
             setChromecastServiceActive(chromecast.active);
@@ -107,6 +116,7 @@ const ControlBar = React.forwardRef(({
             chromecast.off('stateChanged', onStateChanged);
         };
     }, []);
+    const brightnessTitle = typeof brightness === 'number' && !isNaN(brightness) ? `Brightness ${Math.round(brightness)}%` : 'Brightness';
     return (
         <div ref={ref} {...props} onTouchStart={props.onMouseOver} onTouchMove={props.onMouseMove} onTouchEnd={onTouchEnd} className={classnames(className, styles['control-bar-container'])}>
             <SeekBar
@@ -151,11 +161,41 @@ const ControlBar = React.forwardRef(({
                         />
                         : null
                 }
+                {
+                    !platform.isMobile ?
+                        <Button className={styles['control-bar-button']} title={brightnessTitle} tabIndex={-1} onClick={onBrightnessButtonClick}>
+                            <Icon className={styles['icon']} name={'filters'} />
+                        </Button>
+                        : null
+                }
+                {
+                    !platform.isMobile ?
+                        <BrightnessSlider
+                            className={styles['brightness-slider']}
+                            brightness={brightness}
+                            onBrightnessChangeRequested={onBrightnessChangeRequested}
+                        />
+                        : null
+                }
                 <div className={styles['spacing']} />
                 <Button className={styles['control-bar-buttons-menu-button']} onClick={toggleButtonsMenu}>
                     <Icon className={styles['icon']} name={'more-vertical'} />
                 </Button>
                 <div className={classnames(styles['control-bar-buttons-menu-container'], { 'open': buttonsMenuOpen })}>
+                    {
+                        platform.isMobile ?
+                            <div className={styles['control-bar-slider-menu-item']}>
+                                <Button className={styles['control-bar-button']} title={brightnessTitle} tabIndex={-1} onClick={onBrightnessButtonClick}>
+                                    <Icon className={styles['icon']} name={'filters'} />
+                                </Button>
+                                <BrightnessSlider
+                                    className={styles['brightness-menu-slider']}
+                                    brightness={brightness}
+                                    onBrightnessChangeRequested={onBrightnessChangeRequested}
+                                />
+                            </div>
+                            : null
+                    }
                     <Button className={classnames(styles['control-bar-button'], { 'disabled': statistics === null || statistics.type === 'Err' || stream === null || typeof stream.infoHash !== 'string' || typeof stream.fileIdx !== 'number' })} tabIndex={-1} onMouseDown={onStatisticsButtonMouseDown} onClick={onToggleStatisticsMenu}>
                         <Icon className={styles['icon']} name={'network'} />
                     </Button>
@@ -198,6 +238,7 @@ ControlBar.propTypes = {
     duration: PropTypes.number,
     buffered: PropTypes.number,
     volume: PropTypes.number,
+    brightness: PropTypes.number,
     muted: PropTypes.bool,
     playbackSpeed: PropTypes.number,
     videoScale: PropTypes.string,
@@ -215,6 +256,7 @@ ControlBar.propTypes = {
     onMuteRequested: PropTypes.func,
     onUnmuteRequested: PropTypes.func,
     onVolumeChangeRequested: PropTypes.func,
+    onBrightnessChangeRequested: PropTypes.func,
     onSeekRequested: PropTypes.func,
     onToggleSubtitlesMenu: PropTypes.func,
     onToggleAudioMenu: PropTypes.func,

--- a/src/routes/Player/ControlBar/styles.less
+++ b/src/routes/Player/ControlBar/styles.less
@@ -48,7 +48,8 @@
             }
         }
 
-        .volume-slider {
+        .volume-slider,
+        .brightness-slider {
             --track-size: 0.35rem;
             --thumb-size: 1rem;
 
@@ -87,7 +88,12 @@
             flex: none;
             display: flex;
             flex-direction: row;
+            align-items: center;
             gap: 0.25rem;
+
+            .control-bar-slider-menu-item {
+                display: none;
+            }
         }
     }
 }
@@ -106,7 +112,8 @@
             overflow: visible;
             gap: 0.15rem;
 
-            .volume-slider {
+            .volume-slider,
+            .brightness-slider {
                 display: none;
             }
 
@@ -116,6 +123,8 @@
 
             .control-bar-buttons-menu-container {
                 position: absolute;
+                display: flex;
+                align-items: center;
                 right: 0rem;
                 bottom: 4.5rem;
                 padding: 0.5rem;
@@ -127,6 +136,25 @@
                 box-shadow: 0 1.35rem 2.7rem @color-background-dark5-40,
                     0 1.1rem 0.85rem @color-background-dark5-20;
                 overflow-x: auto;
+
+                .control-bar-slider-menu-item {
+                    flex: 0 0 auto;
+                    display: flex;
+                    flex-direction: row;
+                    align-items: center;
+                    gap: 0.15rem;
+                    min-width: 14rem;
+                }
+
+                .brightness-menu-slider {
+                    --track-size: 0.35rem;
+                    --thumb-size: 1rem;
+
+                    flex: 1 1 auto;
+                    min-width: 9rem;
+                    height: 4rem;
+                    margin-right: 0.35rem;
+                }
 
                 &:not(:global(.open)) {
                     display: none;

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -35,6 +35,30 @@ const { default: useMediaSession } = require('./useMediaSession');
 
 const findTrackByLang = (tracks, lang) => tracks.find((track) => track.lang === lang || langs.where('1', track.lang)?.[2] === lang);
 const findTrackById = (tracks, id) => tracks.find((track) => track.id === id);
+const DEFAULT_BRIGHTNESS = 100;
+const BRIGHTNESS_STORAGE_KEY = 'stremio.player.brightness';
+const MIN_BRIGHTNESS = 0;
+const MAX_BRIGHTNESS = 200;
+const BRIGHTNESS_STEP = 5;
+
+const clampBrightness = (value) => Math.max(MIN_BRIGHTNESS, Math.min(MAX_BRIGHTNESS, Math.round(value)));
+const getStoredBrightness = () => {
+    if (typeof window === 'undefined') {
+        return DEFAULT_BRIGHTNESS;
+    }
+
+    try {
+        const storedBrightness = window.localStorage.getItem(BRIGHTNESS_STORAGE_KEY);
+        if (storedBrightness === null) {
+            return DEFAULT_BRIGHTNESS;
+        }
+
+        const parsedBrightness = Number(storedBrightness);
+        return Number.isFinite(parsedBrightness) ? clampBrightness(parsedBrightness) : DEFAULT_BRIGHTNESS;
+    } catch {
+        return DEFAULT_BRIGHTNESS;
+    }
+};
 
 const GAMEPAD_HANDLER_ID = 'player';
 
@@ -70,12 +94,24 @@ const Player = ({ urlParams, queryParams }) => {
     const [immersed, setImmersed] = React.useState(true);
     const setImmersedDebounced = React.useCallback(debounce(setImmersed, 3000), []);
     const [fullscreen, , , toggleFullscreen, , setVideoElement] = useFullscreen();
+    const [brightness, setBrightness] = React.useState(getStoredBrightness);
 
     React.useEffect(() => {
         const el = video.containerRef.current?.querySelector('video');
         setVideoElement(el || null);
         return () => setVideoElement(null);
     }, [video.state.manifest]);
+    React.useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        try {
+            window.localStorage.setItem(BRIGHTNESS_STORAGE_KEY, String(brightness));
+        } catch {
+            // ignore persistence failures
+        }
+    }, [brightness]);
 
     const [optionsMenuOpen, , closeOptionsMenu, toggleOptionsMenu] = useBinaryState(false);
     const [subtitlesMenuOpen, , closeSubtitlesMenu, toggleSubtitlesMenu] = useBinaryState(false);
@@ -216,6 +252,11 @@ const Player = ({ urlParams, queryParams }) => {
 
     const onVolumeChangeRequested = React.useCallback((volume) => {
         video.setVolume(volume);
+    }, []);
+    const onBrightnessChangeRequested = React.useCallback((nextBrightness) => {
+        if (typeof nextBrightness === 'number' && !isNaN(nextBrightness)) {
+            setBrightness(clampBrightness(nextBrightness));
+        }
     }, []);
 
     const onSeekRequested = React.useCallback((time) => {
@@ -595,6 +636,11 @@ const Player = ({ urlParams, queryParams }) => {
         }
     }, [video.state.volume], !menusOpen);
 
+    onShortcut('brightness', (combo) => {
+        const nextBrightness = combo === 0 ? brightness + BRIGHTNESS_STEP : brightness - BRIGHTNESS_STEP;
+        onBrightnessChangeRequested(nextBrightness);
+    }, [brightness, onBrightnessChangeRequested], !menusOpen);
+
     onShortcut('audioMenu', () => {
         closeMenus();
         if (video.state?.audioTracks?.length > 0) {
@@ -779,6 +825,7 @@ const Player = ({ urlParams, queryParams }) => {
             <Video
                 ref={video.containerRef}
                 className={styles['layer']}
+                brightness={brightness}
                 onClick={onVideoClick}
                 onDoubleClick={onVideoDoubleClick}
             />
@@ -862,6 +909,7 @@ const Player = ({ urlParams, queryParams }) => {
                 duration={video.state.duration}
                 buffered={video.state.buffered}
                 volume={video.state.volume}
+                brightness={brightness}
                 muted={video.state.muted}
                 playbackSpeed={video.state.playbackSpeed}
                 subtitlesTracks={allSubtitleTracks}
@@ -876,6 +924,7 @@ const Player = ({ urlParams, queryParams }) => {
                 onMuteRequested={onMuteRequested}
                 onUnmuteRequested={onUnmuteRequested}
                 onVolumeChangeRequested={onVolumeChangeRequested}
+                onBrightnessChangeRequested={onBrightnessChangeRequested}
                 onSeekRequested={onSeekRequested}
                 onToggleOptionsMenu={toggleOptionsMenu}
                 onToggleSubtitlesMenu={toggleSubtitlesMenu}

--- a/src/routes/Player/Video/Video.js
+++ b/src/routes/Player/Video/Video.js
@@ -4,11 +4,14 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const classnames = require('classnames');
 const styles = require('./styles');
-
-const Video = React.forwardRef(({ className, onClick, onDoubleClick }, ref) => {
+const Video = React.forwardRef(({ brightness, className, onClick, onDoubleClick }, ref) => {
+    const brightnessStyle = typeof brightness === 'number' && !isNaN(brightness) ?
+        { '--video-brightness': `${Math.max(0, brightness) / 100}` }
+        :
+        undefined;
     return (
         <div className={classnames(className, styles['video-container'])} onClick={onClick} onDoubleClick={onDoubleClick}>
-            <div ref={ref} className={styles['video']} />
+            <div ref={ref} className={styles['video']} style={brightnessStyle} />
         </div>
     );
 });
@@ -16,6 +19,7 @@ const Video = React.forwardRef(({ className, onClick, onDoubleClick }, ref) => {
 Video.displayName = 'Video';
 
 Video.propTypes = {
+    brightness: PropTypes.number,
     className: PropTypes.string,
     onClick: PropTypes.func,
     onDoubleClick: PropTypes.func,

--- a/src/routes/Player/Video/styles.less
+++ b/src/routes/Player/Video/styles.less
@@ -4,6 +4,12 @@
     .video {
         width: 100%;
         height: 100%;
+        :global(video),
+        :global(canvas),
+        :global(iframe) {
+            filter: brightness(var(--video-brightness, 1));
+            transition: filter 150ms ease;
+        }
 
         * {
             font-size: inherit;


### PR DESCRIPTION
## Summary
- add player brightness controls to the desktop and mobile player UI
- persist brightness level across player sessions
- add keyboard shortcuts for brightness adjustment (`Shift+Up` / `Shift+Down`)

## Validation
- pnpm lint
- pnpm build
- pnpm exec jest --runInBand --passWithNoTests

Conversation: https://app.warp.dev/conversation/b8aa237c-3acc-40b3-a89d-26a7bedeb7d9

Co-Authored-By: Oz <oz-agent@warp.dev>