### PR TITLE
Settings: Capitalize interface language names

### DIFF
--- a/src/routes/Settings/Interface/useInterfaceOptions.ts
+++ b/src/routes/Settings/Interface/useInterfaceOptions.ts
@@ -22,7 +22,7 @@ const useInterfaceOptions = (profile: Profile) => {
     }, [sortedOptions]);
 
     const interfaceLanguageSelect = useMemo(() => ({
-        
+
         options: sortedLanguageOptions,
         value:
             interfaceLanguages.find(({ codes }) => codes[1] === profile.settings.interfaceLanguage)?.codes?.[0] ||

--- a/src/routes/Settings/Interface/useInterfaceOptions.ts
+++ b/src/routes/Settings/Interface/useInterfaceOptions.ts
@@ -39,7 +39,7 @@ const useInterfaceOptions = (profile: Profile) => {
                 }
             });
         }
-    
+
     }), [profile.settings, sortedLanguageOptions]);
 
     const escExitFullscreenToggle = useMemo(() => ({

--- a/src/routes/Settings/Interface/useInterfaceOptions.ts
+++ b/src/routes/Settings/Interface/useInterfaceOptions.ts
@@ -12,7 +12,14 @@ const useInterfaceOptions = (profile: Profile) => {
         })),
     []);
 
-    const { sortedOptions } = useLanguageSorting(interfaceLanguageOptions);
+    const { sortedOptions } = useLanguageSorting(languageOptions);
+
+    const sortedLanguageOptions = useMemo(() => {
+        return sortedOptions.map(opt => ({
+            ...opt,
+            label: opt.label ? opt.label.charAt(0).toUpperCase() + opt.label.slice(1) : opt.label
+        }));
+    }, [sortedOptions]);
 
     const interfaceLanguageSelect = useMemo(() => ({
         options: sortedOptions,

--- a/src/routes/Settings/Interface/useInterfaceOptions.ts
+++ b/src/routes/Settings/Interface/useInterfaceOptions.ts
@@ -12,17 +12,20 @@ const useInterfaceOptions = (profile: Profile) => {
         })),
     []);
 
-    const { sortedOptions } = useLanguageSorting(languageOptions);
+    // 1. Περνάμε τη σωστή μεταβλητή στο hook ταξινόμησης
+    const { sortedOptions } = useLanguageSorting(interfaceLanguageOptions);
 
+    // 2. Κάνουμε capitalize το πρώτο γράμμα
     const sortedLanguageOptions = useMemo(() => {
-        return sortedOptions.map(opt => ({
+        return sortedOptions.map((opt) => ({
             ...opt,
             label: opt.label ? opt.label.charAt(0).toUpperCase() + opt.label.slice(1) : opt.label
         }));
     }, [sortedOptions]);
 
     const interfaceLanguageSelect = useMemo(() => ({
-        options: sortedOptions,
+        // 3. Χρησιμοποιούμε το διορθωμένο array με τα κεφαλαία γράμματα
+        options: sortedLanguageOptions,
         value:
             interfaceLanguages.find(({ codes }) => codes[1] === profile.settings.interfaceLanguage)?.codes?.[0] ||
             profile.settings.interfaceLanguage,
@@ -38,7 +41,8 @@ const useInterfaceOptions = (profile: Profile) => {
                 }
             });
         }
-    }), [profile.settings, sortedOptions]);
+    // 4. Προσθέτουμε το σωστό dependency στο useMemo
+    }), [profile.settings, sortedLanguageOptions]);
 
     const escExitFullscreenToggle = useMemo(() => ({
         checked: profile.settings.escExitFullscreen,

--- a/src/routes/Settings/Interface/useInterfaceOptions.ts
+++ b/src/routes/Settings/Interface/useInterfaceOptions.ts
@@ -12,10 +12,8 @@ const useInterfaceOptions = (profile: Profile) => {
         })),
     []);
 
-    // 1. Περνάμε τη σωστή μεταβλητή στο hook ταξινόμησης
     const { sortedOptions } = useLanguageSorting(interfaceLanguageOptions);
 
-    // 2. Κάνουμε capitalize το πρώτο γράμμα
     const sortedLanguageOptions = useMemo(() => {
         return sortedOptions.map((opt) => ({
             ...opt,
@@ -24,7 +22,7 @@ const useInterfaceOptions = (profile: Profile) => {
     }, [sortedOptions]);
 
     const interfaceLanguageSelect = useMemo(() => ({
-        // 3. Χρησιμοποιούμε το διορθωμένο array με τα κεφαλαία γράμματα
+        
         options: sortedLanguageOptions,
         value:
             interfaceLanguages.find(({ codes }) => codes[1] === profile.settings.interfaceLanguage)?.codes?.[0] ||
@@ -41,7 +39,7 @@ const useInterfaceOptions = (profile: Profile) => {
                 }
             });
         }
-    // 4. Προσθέτουμε το σωστό dependency στο useMemo
+    
     }), [profile.settings, sortedLanguageOptions]);
 
     const escExitFullscreenToggle = useMemo(() => ({


### PR DESCRIPTION
Capitalize the first letter of the UI language names, to match the appearance of subtitle language and audio language selection
<img width="1051" height="1030" alt="image" src="https://github.com/user-attachments/assets/821c6975-ff16-40f9-81f7-fd5f80999f37" />
