### PR TITLE
fix(discover): stop infinite auto-pagination on short catalog results

### DIFF
--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -27,9 +27,13 @@ const Discover = ({ urlParams, queryParams }) => {
         return discover.catalog?.content.type === 'Ready' &&
             discover.catalog.content.content[selectedMetaItemIndex] || null;
     }, [discover.catalog, selectedMetaItemIndex]);
+    const readyCatalogItemsCount = discover.catalog?.content.type === 'Ready' ? discover.catalog.content.content.length : null;
 
     const metasContainerRef = React.useRef();
     const metaPreviewRef = React.useRef();
+    const autoLoadInFlightRef = React.useRef(false);
+    const autoLoadSuppressedRef = React.useRef(false);
+    const previousReadyItemsCountRef = React.useRef(null);
 
     React.useEffect(() => {
         if (discover.catalog?.content.type === 'Loading') {
@@ -37,14 +41,35 @@ const Discover = ({ urlParams, queryParams }) => {
         }
     }, [discover.catalog]);
     React.useEffect(() => {
-        if (hasNextPage && metasContainerRef.current) {
+        if (
+            discover.catalog?.content.type === 'Ready' &&
+            hasNextPage &&
+            metasContainerRef.current &&
+            !autoLoadInFlightRef.current &&
+            !autoLoadSuppressedRef.current
+        ) {
             const containerHeight = metasContainerRef.current.scrollHeight;
             const viewportHeight = metasContainerRef.current.clientHeight;
             if (containerHeight <= viewportHeight + SCROLL_TO_BOTTOM_THRESHOLD) {
+                autoLoadInFlightRef.current = true;
                 loadNextPage();
             }
         }
-    }, [hasNextPage, loadNextPage]);
+    }, [discover.catalog, hasNextPage, loadNextPage]);
+    React.useEffect(() => {
+        if (readyCatalogItemsCount === null) {
+            return;
+        }
+
+        const previousReadyItemsCount = previousReadyItemsCountRef.current;
+        if (autoLoadInFlightRef.current && previousReadyItemsCount !== null) {
+            const itemsGrowth = readyCatalogItemsCount - previousReadyItemsCount;
+            autoLoadInFlightRef.current = false;
+            autoLoadSuppressedRef.current = itemsGrowth <= 0 || itemsGrowth < CONSTANTS.CATALOG_PAGE_SIZE;
+        }
+
+        previousReadyItemsCountRef.current = readyCatalogItemsCount;
+    }, [readyCatalogItemsCount]);
     const addToLibrary = React.useCallback(() => {
         if (selectedMetaItem === null) {
             return;
@@ -109,6 +134,9 @@ const Discover = ({ urlParams, queryParams }) => {
         closeInputsModal();
         closeAddonModal();
         setSelectedMetaItemIndex(0);
+        autoLoadInFlightRef.current = false;
+        autoLoadSuppressedRef.current = false;
+        previousReadyItemsCountRef.current = null;
     }, [discover.selected]);
     return (
         <MainNavBars className={styles['discover-container']} route={'discover'}>


### PR DESCRIPTION
  ## Summary

  Fixes an infinite auto-pagination issue in the Discover catalog view when an addon returns fewer results than `CATALOG_PAGE_SIZE`.

  The Discover route was auto-loading more pages whenever the rendered catalog did not fill the viewport. If the backend kept reporting
  `nextPage = true` even after a short or empty page, the UI could keep issuing repeated requests. This change adds a local guard in `Discover`
  to stop automatic viewport-fill pagination once a fetch returns too few or no new items, while preserving manual scroll-triggered pagination.

  ## Changes

  - track automatic Discover pagination state per selected catalog
  - prevent repeated auto-fetches when the last automatic page adds fewer than `CATALOG_PAGE_SIZE` items
  - stop auto-fetching when a page adds no new items
  - reset auto-pagination guards when the selected catalog/filter changes
  - keep bottom-scroll pagination behavior unchanged

  ## Testing

  - verified lint passes for `src/routes/Discover/Discover.js`
  - manually validate Discover catalogs that return:
    - fewer than `CATALOG_PAGE_SIZE` items on the first page
    - short later pages
    - no new items while `nextPage` remains true

  ## Issue

  Closes #1144