### PR TITLE
fix: missed window focus event leaves model state subscriptions unattached

### DIFF
--- a/src/common/useRouteFocused.ts
+++ b/src/common/useRouteFocused.ts
@@ -15,6 +15,9 @@ const useRouteFocused = () => {
         window.addEventListener('focus', handleFocus);
         window.addEventListener('blur', handleBlur);
 
+        // catch focus changes that happened before the listeners were attached
+        setIsFocused(document.hasFocus());
+
         return () => {
             window.removeEventListener('focus', handleFocus);
             window.removeEventListener('blur', handleBlur);


### PR DESCRIPTION
## What happens

1. `useRouteFocused` initializes `isFocused` from `document.hasFocus()` during the initial render.
2. Its `focus`/`blur` listeners are attached in a `useEffect`, which runs after the commit.
3. A focus change in the window between (1) and (2) is never observed. If `document.hasFocus()` was `false` during the initial render and the window gains focus before the effect runs, `isFocused` stays `false`, and nothing corrects it later: the next `focus` event only fires after the window is blurred and refocused.
4. `useModelState` only attaches `core.on('state', ...)` while `useRouteFocused()` returns `true`. Components affected by (3) never subscribe, so they never call `getState` again and keep rendering the state snapshot taken at mount.

The gap in (3) is real time, not theoretical: the initial render of the route content and the effect flush are separated by the first commit of a large tree. A window that gains OS focus while the page is booting (for example when a deep link is opened from another application and the browser window is focused as part of the navigation) can land the focus change inside it.

## Observed behavior

Reproduced on web.stremio.com v6.0.1-beta.06, Chrome 149, macOS, with `document.hasFocus()` returning `false`:

- A detail deep link renders "No meta was selected!" and never updates, while the core loads the meta and emits `NewState` for `meta_details` (13 emissions observed over 3s with no `getState` call following any of them; a healthy boot calls `getState('meta_details')` after each one).
- Changing the hash from `.../tt10405370:1:2` to `.../tt10405370:1:3` leaves the streams panel on S1E2.
- `window.dispatchEvent(new Event('focus'))` recovers the page immediately: `isFocused` flips, the effect in `useModelState` re-runs, subscribes, and resyncs via `onNewState([model])`.

## Fix

Re-read `document.hasFocus()` inside the effect, after attaching the listeners. Any focus change that happened before the listeners existed is then picked up, and changes after are covered by the listeners.

Verified against a production build with `document.hasFocus()` stubbed to `false` during the initial render and restored before the effect ran, without firing any focus event: the app boots with content and hash navigation keeps updating.


Supersedes #1333, which could not be reopened after a force-push to the branch.
