### PR TITLE
Player: Avoid reloading external subtitles

### DIFF
--- a/src/routes/Player/useSubtitles.ts
+++ b/src/routes/Player/useSubtitles.ts
@@ -197,8 +197,9 @@ const useSubtitles = ({
         }
 
         if (extraTrack?.id) {
-            if (video.state.selectedExtraSubtitlesTrackId !== extraTrack.id ||
-                video.state.selectedSubtitlesTrackId !== null) {
+            // Keep the first external match while waiting for an embedded track.
+            // Add-on subtitle results can arrive in stages and reorder `extraTrack`.
+            if (video.state.selectedExtraSubtitlesTrackId === null) {
                 video.setExtraSubtitlesTrack(extraTrack.id);
             }
 


### PR DESCRIPTION
Keeps the first external fallback selected while subtitle add-on results are still arriving.