### PR TITLE
Player: Flush keyboard seek on release

### DIFF
--- a/src/routes/Player/useKeyboardSeek.ts
+++ b/src/routes/Player/useKeyboardSeek.ts
@@ -86,7 +86,7 @@ const useKeyboardSeek = ({ time, duration, onSeek, setSeeking }: Props) => {
         stopHold();
         if (pendingRef.current) {
             commit();
-            commit.flush();
+            requestAnimationFrame(commit.flush);
         }
     }, []);
     const seekTo = useCallback((time: number) => {

--- a/src/routes/Player/useKeyboardSeek.ts
+++ b/src/routes/Player/useKeyboardSeek.ts
@@ -86,6 +86,7 @@ const useKeyboardSeek = ({ time, duration, onSeek, setSeeking }: Props) => {
         stopHold();
         if (pendingRef.current) {
             commit();
+            commit.flush();
         }
     }, []);
     const seekTo = useCallback((time: number) => {


### PR DESCRIPTION
Remove the extra 300 ms wait after releasing an arrow key while keeping repeated keydowns accumulated.

Related to Stremio/stremio-bugs#2705.