### PR TITLE
Player: Prevent subtitle selection from context menu

### DIFF
--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -112,7 +112,8 @@ const ContextMenu = ({ children, on, autoClose, lock }: Props) => {
 
     const handleKeyDown = useCallback((event: KeyboardEvent) => event.key === 'Escape' && close(), [close]);
 
-    const onClick = useCallback(() => {
+    const onClick = useCallback((event: React.MouseEvent) => {
+        event.stopPropagation();
         autoClose && close();
     }, [autoClose, close]);
 


### PR DESCRIPTION
Stop portal context-menu clicks from bubbling into the subtitle row while keeping menu actions and auto-close unchanged.