### PR TITLE
Fixed TV Addon Sync: reactivity, visibility fallback, and manual sync

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -174,9 +174,16 @@ const App = () => {
 
         onWindowFocus();
         window.addEventListener('focus', onWindowFocus);
+        const onVisibilityChange = () => {
+            if (document.visibilityState === 'visible') {
+                onWindowFocus();
+            }
+        };
+        document.addEventListener('visibilitychange', onVisibilityChange);
 
         return () => {
             window.removeEventListener('focus', onWindowFocus);
+            document.removeEventListener('visibilitychange', onVisibilityChange);
         };
     }, []);
 

--- a/src/routes/Addons/useInstalledAddons.js
+++ b/src/routes/Addons/useInstalledAddons.js
@@ -23,7 +23,7 @@ const useInstalledAddons = (urlParams) => {
             };
         }
     }, [urlParams]);
-    return useModelState({ model: 'installed_addons', action });
+    return useModelState({ model: 'installed_addons', action, deps: ['ctx'] });
 };
 
 module.exports = useInstalledAddons;

--- a/src/routes/Settings/General/General.tsx
+++ b/src/routes/Settings/General/General.tsx
@@ -31,6 +31,39 @@ const General = forwardRef<HTMLDivElement, Props>(({ profile }: Props, ref) => {
         loadDataExport();
     }, []);
 
+    const onSyncWithAPI = useCallback(() => {
+        core.transport.dispatch({
+            action: 'Ctx',
+            args: {
+                action: 'PullAddonsFromAPI'
+            }
+        });
+        core.transport.dispatch({
+            action: 'Ctx',
+            args: {
+                action: 'PullUserFromAPI',
+                args: {}
+            }
+        });
+        core.transport.dispatch({
+            action: 'Ctx',
+            args: {
+                action: 'SyncLibraryWithAPI'
+            }
+        });
+        core.transport.dispatch({
+            action: 'Ctx',
+            args: {
+                action: 'PullNotifications'
+            }
+        });
+        toast.show({
+            type: 'success',
+            title: t('SETTINGS_SYNC_NOW_TOAST'),
+            timeout: 4000
+        });
+    }, []);
+
     const onCalendarSubscribe = useCallback(() => {
         if (!profile.auth) return;
 
@@ -107,6 +140,13 @@ const General = forwardRef<HTMLDivElement, Props>(({ profile }: Props, ref) => {
                     <Link
                         label={t('SETTINGS_DATA_EXPORT')}
                         onClick={onExportData}
+                    />
+            }
+            {
+                profile?.auth?.user &&
+                    <Link
+                        label={t('SETTINGS_SYNC_NOW')}
+                        onClick={onSyncWithAPI}
                     />
             }
             {


### PR DESCRIPTION
Fix 1 (Critical): Added missing deps: ['ctx'] to useInstalledAddons.js so the installed addons list reacts to API sync results.
Fix 2 (TV Support): Added a visibilitychange listener in App.js as a fallback, because TV webviews (Tizen, webOS) do not fire window.focus events.
Fix 3 (UX): Added a manual "Sync Now" button in Settings > General for TV users