### PR TITLE
Player: Preserve subtitle preference while binge watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@babel/runtime": "7.29.2",
         "@sentry/browser": "8.42.0",
         "@stremio/stremio-colors": "5.2.0",
-        "@stremio/stremio-core-web": "0.60.2",
+        "@stremio/stremio-core-web": "https://stremio.github.io/stremio-core/stremio-core-web/feat/player-subtitle-preference/stremio-stremio-core-web-0.60.2.tgz",
         "@stremio/stremio-icons": "5.10.0",
         "@stremio/stremio-video": "0.0.90",
         "a-color-picker": "1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 5.2.0
         version: 5.2.0
       '@stremio/stremio-core-web':
-        specifier: 0.60.2
-        version: 0.60.2
+        specifier: https://stremio.github.io/stremio-core/stremio-core-web/feat/player-subtitle-preference/stremio-stremio-core-web-0.60.2.tgz
+        version: https://stremio.github.io/stremio-core/stremio-core-web/feat/player-subtitle-preference/stremio-stremio-core-web-0.60.2.tgz
       '@stremio/stremio-icons':
         specifier: 5.10.0
         version: 5.10.0
@@ -1417,8 +1417,9 @@ packages:
   '@stremio/stremio-colors@5.2.0':
     resolution: {integrity: sha512-dYlPgu9W/H7c9s1zmW5tiDnRenaUa4Hg1QCyOg1lhOcgSfM/bVTi5nnqX+IfvGTTUNA0zgzh8hI3o3miwnZxTg==}
 
-  '@stremio/stremio-core-web@0.60.2':
-    resolution: {integrity: sha512-27JYuy52qIcLv9M7wV5ex3qD6bbn0oqhmuU3syO96dTficDgdpUpo01wz0fgjFWl/JbCAzyJBZ/ocIE4cU+3yA==}
+  '@stremio/stremio-core-web@https://stremio.github.io/stremio-core/stremio-core-web/feat/player-subtitle-preference/stremio-stremio-core-web-0.60.2.tgz':
+    resolution: {integrity: sha512-ZIatR14rH7rB74EBR58qUb1f4z2M2PZk9S5jK0HBnr6dwLpcBIDbliN40S12IHn94GLixo4ixZgokvWRJyamHg==, tarball: https://stremio.github.io/stremio-core/stremio-core-web/feat/player-subtitle-preference/stremio-stremio-core-web-0.60.2.tgz}
+    version: 0.60.2
 
   '@stremio/stremio-icons@5.10.0':
     resolution: {integrity: sha512-Zw/vGC3D2yeQfk8xv/tfMJTDvbCPOI91tBg4XpR2+EgbZSX8Xvm7Vz457PIhFPhTAwdOPHp0VX0M3gzjbt0zOg==}
@@ -6482,7 +6483,7 @@ snapshots:
 
   '@stremio/stremio-colors@5.2.0': {}
 
-  '@stremio/stremio-core-web@0.60.2':
+  '@stremio/stremio-core-web@https://stremio.github.io/stremio-core/stremio-core-web/feat/player-subtitle-preference/stremio-stremio-core-web-0.60.2.tgz':
     dependencies:
       '@babel/runtime': 7.24.1
 

--- a/src/core/types/models/Player.d.ts
+++ b/src/core/types/models/Player.d.ts
@@ -42,6 +42,13 @@ type AudioTrackState = {
     id: string,
 };
 
+type SubtitleSource = 'embedded' | 'external';
+
+type SubtitlePreference = {
+    enabled: boolean,
+    source?: SubtitleSource,
+};
+
 type StreamState = {
     subtitleTrack?: SubtitlesTrackState | null,
     subtitleDelay?: number,
@@ -63,6 +70,7 @@ type Player = {
     } | null,
     seriesInfo: SeriesInfo | null,
     streamState: StreamState | null,
+    subtitlePreference: SubtitlePreference | null,
     subtitles: Subtitle[],
     title: string | null,
 };

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -65,7 +65,7 @@ const Player = () => {
         return queryParams.has('forceTranscoding');
     }, [queryParams]);
     const profile = useProfile();
-    const [player, videoParamsChanged, streamStateChanged, timeChanged, seek, pausedChanged, ended, nextVideo] = usePlayer(urlParams);
+    const [player, videoParamsChanged, streamStateChanged, subtitlePreferenceChanged, timeChanged, seek, pausedChanged, ended, nextVideo] = usePlayer(urlParams);
     const [settings] = useSettings();
     const streamingServer = useStreamingServer();
     const statistics = useStatistics(player, streamingServer);
@@ -168,6 +168,7 @@ const Player = () => {
         video,
         settings,
         streamStateChanged,
+        subtitlePreferenceChanged,
         menusOpen,
         closeMenus,
         closeSubtitlesMenu,

--- a/src/routes/Player/usePlayer.d.ts
+++ b/src/routes/Player/usePlayer.d.ts
@@ -1,9 +1,11 @@
 declare const usePlayer: (urlParams: UrlParams) => [
     Player,
     videoParamsChanged: (videoParams: { hash: string | null, size: number | null, filename: string | null }) => void,
+    streamStateChanged: (state: Partial<StreamState>) => void,
+    subtitlePreferenceChanged: (preference: SubtitlePreference) => void,
     timeChanged: (time: number, duration: number, device: string) => void,
     seek: (time: number, duration: number, device: string) => void,
-    pausedChanged: (paused: boolean) => void, () => void, () => void,
+    pausedChanged: (paused: boolean) => void,
     ended: () => void,
     nextVideo: () => void,
 ];

--- a/src/routes/Player/usePlayer.js
+++ b/src/routes/Player/usePlayer.js
@@ -171,7 +171,17 @@ const usePlayer = (urlParams) => {
         }, 'player');
     }, [player.streamState]);
 
-    return [player, videoParamsChanged, streamStateChanged, timeChanged, seek, pausedChanged, ended, nextVideo];
+    const subtitlePreferenceChanged = React.useCallback((preference) => {
+        return core.transport.dispatch({
+            action: 'Player',
+            args: {
+                action: 'SubtitlePreferenceChanged',
+                args: { preference },
+            },
+        }, 'player');
+    }, []);
+
+    return [player, videoParamsChanged, streamStateChanged, subtitlePreferenceChanged, timeChanged, seek, pausedChanged, ended, nextVideo];
 };
 
 module.exports = usePlayer;

--- a/src/routes/Player/useSubtitles.d.ts
+++ b/src/routes/Player/useSubtitles.d.ts
@@ -56,6 +56,7 @@ type UseSubtitlesArgs = {
     video: VideoController,
     settings: Settings,
     streamStateChanged: (state: Partial<StreamState>) => void,
+    subtitlePreferenceChanged: (preference: SubtitlePreference) => void,
     menusOpen: boolean,
     closeMenus: () => void,
     closeSubtitlesMenu: () => void,

--- a/src/routes/Player/useSubtitles.ts
+++ b/src/routes/Player/useSubtitles.ts
@@ -40,6 +40,7 @@ const useSubtitles = ({
     video,
     settings,
     streamStateChanged,
+    subtitlePreferenceChanged,
     menusOpen,
     closeMenus,
     closeSubtitlesMenu,
@@ -89,14 +90,30 @@ const useSubtitles = ({
                 lang: track.lang,
             },
         });
-    }, [streamStateChanged]);
+        subtitlePreferenceChanged({
+            enabled: true,
+            source: embedded ? 'embedded' : 'external',
+        });
+    }, [streamStateChanged, subtitlePreferenceChanged]);
 
     const disableSubtitles = useCallback(() => {
+        const source = video.state.selectedSubtitlesTrackId !== null ?
+            'embedded'
+            :
+            video.state.selectedExtraSubtitlesTrackId !== null ?
+                'external'
+                :
+                player.subtitlePreference?.source;
+
         defaultTrackSelected.current = true;
         video.setSubtitlesTrack(null);
         video.setExtraSubtitlesTrack(null);
         streamStateChanged({ subtitleTrack: null });
-    }, [streamStateChanged, video]);
+        subtitlePreferenceChanged({
+            enabled: false,
+            ...(source ? { source } : {}),
+        });
+    }, [player.subtitlePreference?.source, streamStateChanged, subtitlePreferenceChanged, video]);
 
     const selectEmbeddedTrack = useCallback((track: SubtitleTrack | null) => {
         if (!track) {
@@ -162,11 +179,20 @@ const useSubtitles = ({
     }, [externalSubtitles, video.state.stream]);
 
     useEffect(() => {
+        defaultTrackSelected.current = false;
+        lastSelectedTrack.current = null;
+    }, [video.state.stream]);
+
+    useEffect(() => {
         if (defaultTrackSelected.current) {
             return;
         }
 
-        if (settings.subtitlesLanguage === null) {
+        const sessionPreference = player.subtitlePreference;
+        const sessionEnabled = sessionPreference?.enabled === true;
+        const preferredSource = sessionEnabled ? sessionPreference.source : undefined;
+
+        if (sessionPreference?.enabled === false || (!sessionEnabled && settings.subtitlesLanguage === null)) {
             video.setSubtitlesTrack(null);
             video.setExtraSubtitlesTrack(null);
             defaultTrackSelected.current = true;
@@ -177,34 +203,53 @@ const useSubtitles = ({
         const savedTrackId = savedTrack?.id;
         const savedLanguage = savedTrack?.lang;
         const savedExternalTrack = Boolean(savedTrackId && savedTrack?.embedded === false);
-        const embeddedTrack = savedTrackId ?
-            findTrackById(video.state.subtitlesTracks, savedTrackId)
-            :
-            findTrackByLanguage(video.state.subtitlesTracks, savedLanguage ?? settings.subtitlesLanguage);
-        const extraTrack = savedTrackId ?
-            findTrackById(video.state.extraSubtitlesTracks, savedTrackId)
-            :
-            findTrackByLanguage(video.state.extraSubtitlesTracks, savedLanguage ?? settings.subtitlesLanguage);
+        const findDefaultTrack = (tracks: SubtitleTrack[], embedded: boolean) => {
+            if (savedTrackId && (preferredSource === undefined || savedTrack?.embedded === embedded)) {
+                return findTrackById(tracks, savedTrackId);
+            }
+
+            const language = savedLanguage ?? settings.subtitlesLanguage;
+            return findTrackByLanguage(tracks, language) ?? (sessionEnabled && !language ? tracks[0] : undefined);
+        };
+        const embeddedTrack = findDefaultTrack(video.state.subtitlesTracks, true);
+        const extraTrack = findDefaultTrack(video.state.extraSubtitlesTracks, false);
+
+        if (preferredSource === 'external') {
+            if (extraTrack?.id) {
+                video.setExtraSubtitlesTrack(extraTrack.id);
+                defaultTrackSelected.current = true;
+                return;
+            }
+
+            if (embeddedTrack?.id && (video.state.selectedSubtitlesTrackId !== embeddedTrack.id ||
+                video.state.selectedExtraSubtitlesTrackId !== null)) {
+                video.setSubtitlesTrack(embeddedTrack.id);
+            }
+
+            return;
+        }
 
         if (embeddedTrack?.id) {
             video.setSubtitlesTrack(embeddedTrack.id);
-
             defaultTrackSelected.current = true;
             return;
         }
 
         if (extraTrack?.id) {
+            if (savedExternalTrack && preferredSource === undefined) {
+                video.setExtraSubtitlesTrack(extraTrack.id);
+                defaultTrackSelected.current = true;
+                return;
+            }
+
             // Keep the first external match while waiting for an embedded track.
             // Add-on subtitle results can arrive in stages and reorder `extraTrack`.
             if (video.state.selectedExtraSubtitlesTrackId === null) {
                 video.setExtraSubtitlesTrack(extraTrack.id);
             }
-
-            if (savedExternalTrack) {
-                defaultTrackSelected.current = true;
-            }
         }
     }, [
+        player.subtitlePreference,
         player.streamState,
         settings.subtitlesLanguage,
         video.state.extraSubtitlesTracks,
@@ -232,11 +277,6 @@ const useSubtitles = ({
             video.setSubtitlesOffset(offset);
         }
     }, [player.streamState, video.state.stream]);
-
-    useEffect(() => {
-        defaultTrackSelected.current = false;
-        lastSelectedTrack.current = null;
-    }, [video.state.stream]);
 
     useEffect(() => {
         if (!hasTracks) {
@@ -313,20 +353,25 @@ const useSubtitles = ({
                 };
             }
 
-            video.setSubtitlesTrack(null);
-            video.setExtraSubtitlesTrack(null);
+            disableSubtitles();
             return;
         }
 
         const savedTrack = player.streamState?.subtitleTrack ?? lastSelectedTrack.current;
         if (savedTrack?.id) {
+            subtitlePreferenceChanged({
+                enabled: true,
+                source: savedTrack.embedded ? 'embedded' : 'external',
+            });
             savedTrack.embedded ?
                 video.setSubtitlesTrack(savedTrack.id)
                 :
                 video.setExtraSubtitlesTrack(savedTrack.id);
         }
     }, [
+        disableSubtitles,
         player.streamState,
+        subtitlePreferenceChanged,
         video.state.selectedExtraSubtitlesTrackId,
         video.state.selectedSubtitlesTrackId,
     ], !menusOpen);


### PR DESCRIPTION
Depends on Stremio/stremio-core#1020.

Stacked on #1358.

Related: https://github.com/Stremio/stremio-bugs/issues/2701

---
- Global setting X; episode 1 uses external Y; episode 2 has external X: External X is selected.
- Global setting X; episode 1 uses embedded Y: Embedded Y is carried forward and takes priority.
- Global setting X; both episodes have external X: External X is selected independently for each episode.
- Global setting X; episode 2 has no external X: Embedded X may be used; otherwise no matching subtitles are selected.
- User deliberately turns subtitles off: Subtitles remain off for the session.
- User exits the player: Session state clears and global setting X applies again.