### PR TITLE
Player: let Escape exit the player when not fullscreen

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -789,8 +789,14 @@ const Player = () => {
 
     onShortcut('exit', () => {
         closeMenus();
-        !settings.escExitFullscreen && navigate(-1);
-    }, [settings.escExitFullscreen]);
+        // When escExitFullscreen is enabled, FullscreenProvider handles the first
+        // Escape press by leaving fullscreen. Only skip navigating back in that case,
+        // otherwise Escape would never exit the player in windowed mode.
+        if (settings.escExitFullscreen && fullscreen) {
+            return;
+        }
+        navigate(-1);
+    }, [settings.escExitFullscreen, fullscreen]);
 
     React.useLayoutEffect(() => {
         if (!routeFocused) {


### PR DESCRIPTION
### Problem

`Esc` never exits the player on desktop. Reported in Stremio/stremio-bugs#1450 (and part of Stremio/stremio-bugs#2664).

The exit shortcut skips navigating back whenever the `escExitFullscreen` **setting** is enabled, rather than when the player actually *is* fullscreen:

```js
onShortcut('exit', () => {
    closeMenus();
    !settings.escExitFullscreen && navigate(-1);
}, [settings.escExitFullscreen]);
```

`escExitFullscreen` is on by default on desktop, so `navigate(-1)` is dead code there: Escape leaves fullscreen (handled separately in `FullscreenProvider`) but can never leave the player, in windowed mode or after fullscreen was already exited. In v4 Escape returned to the previous screen.

### Fix

Only swallow the navigation while fullscreen is actually active — `FullscreenProvider` handles that press by exiting fullscreen. Any later Escape (windowed) exits the player.

### Testing

- Fullscreen + setting on: first Escape leaves fullscreen, second exits the player.
- Windowed + setting on: Escape exits the player.
- Setting off: unchanged, Escape exits the player.
- `eslint` clean, `tsc --noEmit` shows no new errors, production build passes.
