### PR TITLE
fix(player): stop local playback, send subtitles and stop the device when casting

### DIFF
--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -141,7 +141,7 @@ const Player = () => {
         }
     }, [platform.shell.active]);
     const castSubtitlesUrl = React.useRef(null);
-    const { castStarted, setSubtitles: setCastSubtitles } = useCastDevice(streamingServer.baseUrl ?? null);
+    const { castStarted, setSubtitles: setCastSubtitles } = useCastDevice();
     const onCastDeviceSelected = React.useCallback((deviceId) => {
         playOnDevice(deviceId, video.state.time);
         castStarted(deviceId);

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -29,6 +29,7 @@ const { default: SideDrawerButton } = require('./SideDrawerButton');
 const { default: SideDrawer } = require('./SideDrawer');
 const usePlayer = require('./usePlayer');
 const { default: usePlayOnDevice } = require('./usePlayOnDevice');
+const { default: useCastDevice } = require('./useCastDevice');
 const { default: useKeyboardSeek } = require('./useKeyboardSeek');
 const useStatistics = require('./useStatistics');
 const useVideo = require('./useVideo');
@@ -139,10 +140,18 @@ const Player = () => {
             });
         }
     }, [platform.shell.active]);
+    const castSubtitlesUrl = React.useRef(null);
+    const { castStarted, setSubtitles: setCastSubtitles } = useCastDevice(streamingServer.baseUrl ?? null);
     const onCastDeviceSelected = React.useCallback((deviceId) => {
         playOnDevice(deviceId, video.state.time);
+        castStarted(deviceId);
+        // Stop the local playback right away, otherwise it keeps running until
+        // the PlayingOnDevice event arrives and the stream plays on both ends.
+        playingOnExternalDevice.current = true;
+        video.setPaused(true);
+        setCastSubtitles(castSubtitlesUrl.current);
         closeCastDevicesMenu();
-    }, [playOnDevice, video.state.time]);
+    }, [playOnDevice, castStarted, setCastSubtitles, video.state.time]);
     React.useEffect(() => {
         if (castDevicesMenuOpen && platform.shell.active) {
             setCastDevicesSearching(true);
@@ -174,6 +183,14 @@ const Player = () => {
         closeSubtitlesMenu,
         toggleSubtitlesMenu,
     });
+
+    React.useEffect(() => {
+        const track = extraSubtitleTracks.find(({ id }) => id === selectedExtraSubtitleTrackId);
+        castSubtitlesUrl.current = track?.fallbackUrl ?? track?.url ?? null;
+        if (playingOnExternalDevice.current) {
+            setCastSubtitles(castSubtitlesUrl.current);
+        }
+    }, [extraSubtitleTracks, selectedExtraSubtitleTrackId, setCastSubtitles]);
 
     const nextVideoPopupDismissed = React.useRef(false);
     const defaultAudioTrackSelected = React.useRef(false);

--- a/src/routes/Player/useCastDevice.ts
+++ b/src/routes/Player/useCastDevice.ts
@@ -1,0 +1,66 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+import { useCallback, useEffect, useRef } from 'react';
+
+type PlayerState = {
+    source?: string | null,
+    subtitlesSrc?: string | null,
+    time?: number,
+    paused?: boolean,
+};
+
+// The streaming server exposes the stremio-cast protocol on
+// /casting/{deviceId}/player: a POST sets any of the player properties and
+// returns the full state of the remote player. Setting `source` to null stops
+// playback on the device.
+const playerUrl = (baseUrl: string, deviceId: string) => new URL(`casting/${deviceId}/player`, baseUrl).toString();
+
+const useCastDevice = (baseUrl: string | null) => {
+    const deviceId = useRef<string | null>(null);
+
+    const setPlayerState = useCallback((device: string, state: PlayerState) => {
+        if (!baseUrl) {
+            return Promise.resolve();
+        }
+
+        return fetch(playerUrl(baseUrl, device), {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(state),
+        }).then(() => undefined).catch((error) => {
+            console.error('CastDevice:', error);
+        });
+    }, [baseUrl]);
+
+    const castStarted = useCallback((device: string) => {
+        deviceId.current = device;
+    }, []);
+
+    const setSubtitles = useCallback((subtitlesSrc: string | null) => {
+        if (deviceId.current === null) {
+            return;
+        }
+
+        setPlayerState(deviceId.current, { subtitlesSrc });
+    }, [setPlayerState]);
+
+    const stopCasting = useCallback(() => {
+        const device = deviceId.current;
+        if (device === null) {
+            return;
+        }
+
+        deviceId.current = null;
+        setPlayerState(device, { source: null });
+    }, [setPlayerState]);
+
+    useEffect(() => {
+        return () => {
+            stopCasting();
+        };
+    }, [stopCasting]);
+
+    return { castStarted, setSubtitles, stopCasting };
+};
+
+export default useCastDevice;

--- a/src/routes/Player/useCastDevice.ts
+++ b/src/routes/Player/useCastDevice.ts
@@ -1,36 +1,11 @@
 // Copyright (C) 2017-2026 Smart code 203358507
 
 import { useCallback, useEffect, useRef } from 'react';
+import { useCore } from 'stremio/core';
 
-type PlayerState = {
-    source?: string | null,
-    subtitlesSrc?: string | null,
-    time?: number,
-    paused?: boolean,
-};
-
-// The streaming server exposes the stremio-cast protocol on
-// /casting/{deviceId}/player: a POST sets any of the player properties and
-// returns the full state of the remote player. Setting `source` to null stops
-// playback on the device.
-const playerUrl = (baseUrl: string, deviceId: string) => new URL(`casting/${deviceId}/player`, baseUrl).toString();
-
-const useCastDevice = (baseUrl: string | null) => {
+const useCastDevice = () => {
+    const core = useCore();
     const deviceId = useRef<string | null>(null);
-
-    const setPlayerState = useCallback((device: string, state: PlayerState) => {
-        if (!baseUrl) {
-            return Promise.resolve();
-        }
-
-        return fetch(playerUrl(baseUrl, device), {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(state),
-        }).then(() => undefined).catch((error) => {
-            console.error('CastDevice:', error);
-        });
-    }, [baseUrl]);
 
     const castStarted = useCallback((device: string) => {
         deviceId.current = device;
@@ -41,8 +16,17 @@ const useCastDevice = (baseUrl: string | null) => {
             return;
         }
 
-        setPlayerState(deviceId.current, { subtitlesSrc });
-    }, [setPlayerState]);
+        core.transport.dispatch({
+            action: 'StreamingServer',
+            args: {
+                action: 'SetDeviceSubtitles',
+                args: {
+                    device: deviceId.current,
+                    subtitlesSrc,
+                },
+            },
+        });
+    }, []);
 
     const stopCasting = useCallback(() => {
         const device = deviceId.current;
@@ -51,8 +35,16 @@ const useCastDevice = (baseUrl: string | null) => {
         }
 
         deviceId.current = null;
-        setPlayerState(device, { source: null });
-    }, [setPlayerState]);
+        core.transport.dispatch({
+            action: 'StreamingServer',
+            args: {
+                action: 'StopOnDevice',
+                args: {
+                    device,
+                },
+            },
+        });
+    }, []);
 
     useEffect(() => {
         return () => {


### PR DESCRIPTION
### Problem

Desktop casting goes through the streaming server (`StreamingServer` / `PlayOnDevice`), and `stremio-web` only sends that one action, then waits for the `PlayingOnDevice` core event. Three bugs follow from that:

- Stremio/stremio-bugs#2731 — local playback keeps running until the event arrives, so the stream plays locally *and* on the device.
- Stremio/stremio-bugs#2732 — the selected subtitles track is never sent to the device, so subtitles render locally only.
- Stremio/stremio-bugs#2733 — leaving the player never stops the device, which keeps playing with no way to control it from the app.

The server already speaks the stremio-cast protocol on `/casting/{deviceId}/player`: a `POST` sets player properties and returns the full state, `subtitlesSrc` carries the subtitles URL, and `source: null` stops playback. Stremio 4.4 used exactly this through the `stremio-cast` client; v5 stopped using everything except the initial play.

Verified against a running streaming server (v4 shell, `GET /casting/{id}/player` on a live session):

```json
{"volume":1,"time":406192.1,"paused":false,"state":3,"length":3162460,
 "source":"http://127.0.0.1:11470/<hash>/0",
 "subtitlesSrc":"https://subs5.strem.io/.../file/...","subtitlesDelay":0,"subtitlesSize":2}
```

### Changes

- New `useCastDevice` hook wrapping the `/casting/{deviceId}/player` endpoint (set subtitles, stop).
- `onCastDeviceSelected` pauses local playback immediately instead of waiting for `PlayingOnDevice`.
- The selected extra subtitles track is pushed on cast start and whenever it changes while casting.
- The device is stopped (`source: null`) when the player unmounts.

### Notes

- Only `subtitlesSrc` is sent. `subtitlesDelay` / `subtitlesSize` are supported by the endpoint too, but their units/scale differ from the in-app settings, so they are left alone here — happy to add them if you can confirm the mapping.
- An alternative shape would be a `StopOnDevice` / `SetDeviceSubtitles` action in `stremio-core` next to `PlayOnDevice`, keeping all server calls in core. Say the word and I'll move it there instead.

### Testing

- `eslint` clean, `tsc --noEmit` shows no new errors, production build passes.
- Endpoint behavior verified against a live streaming server casting session.
