### PR TITLE
NextVideoPopup: Blur next video thumbnail only for unwatched videos

### DIFF
--- a/src/routes/Player/NextVideoPopup/NextVideoPopup.js
+++ b/src/routes/Player/NextVideoPopup/NextVideoPopup.js
@@ -12,7 +12,7 @@ const { useTranslation } = require('react-i18next');
 const NextVideoPopup = ({ className, metaItem, nextVideo, onDismiss, onNextVideoRequested }) => {
     const { t } = useTranslation();
     const profile = useProfile();
-    const blurPosterImage = profile.settings.hideSpoilers && metaItem.type === 'series';
+    const blurPosterImage = profile.settings.hideSpoilers && metaItem.type === 'series' && !nextVideo?.watched;
     const watchNowButtonRef = React.useRef(null);
     const [animationEnded, setAnimationEnded] = React.useState(false);
     const videoName = React.useMemo(() => {


### PR DESCRIPTION
Currently, when `hideSpoilers` setting is active, NextVideoPopup thumbnail is always blurred, even if next episode is already marked as watched. This PR aligns the logic with SideDrawer/MetaDetails thumbnails so that a thumbnail is blurred only if `hideSpoilers` setting in ON and the video is not watched.