### PR TITLE
MultiselectMenu: Keep arrow-key navigation inside the open dropdown

### DIFF
--- a/src/components/MultiselectMenu/Dropdown/Dropdown.less
+++ b/src/components/MultiselectMenu/Dropdown/Dropdown.less
@@ -16,6 +16,7 @@
     box-shadow: var(--outer-glow);
     border-radius: var(--border-radius);
     overflow: hidden;
+    --spatial-navigation-contain: contain;
 
     &.open {
         display: block;


### PR DESCRIPTION
Fixes issue [#2664](https://github.com/Stremio/stremio-bugs/issues/2664)