### PR TITLE
Player: reflect video scale mode in control icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@sentry/browser": "8.42.0",
         "@stremio/stremio-colors": "5.2.0",
         "@stremio/stremio-core-web": "0.61.0",
-        "@stremio/stremio-icons": "5.14.0",
+        "@stremio/stremio-icons": "5.15.0",
         "@stremio/stremio-video": "0.0.93",
         "a-color-picker": "1.2.1",
         "bowser": "2.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 0.61.0
         version: 0.61.0
       '@stremio/stremio-icons':
-        specifier: 5.14.0
-        version: 5.14.0
+        specifier: 5.15.0
+        version: 5.15.0
       '@stremio/stremio-video':
         specifier: 0.0.93
         version: 0.0.93
@@ -1427,8 +1427,8 @@ packages:
   '@stremio/stremio-core-web@0.61.0':
     resolution: {integrity: sha512-Wx3lDU5221rjg5U/ATgSg/e9crAbB2+/l4inlvl+lCHY6AlhOrcw+Po9+LPa6eLVkd2afjHTkBnUcnS92e7dkg==}
 
-  '@stremio/stremio-icons@5.14.0':
-    resolution: {integrity: sha512-+12Y2CW2Pir4jDO9MPg4Fec+WxIUXlAJKeVK3Cq1lRWEElCpRZ/YRqsY5e28VpiYwIfbjaHElXktZRZ71vXHcg==}
+  '@stremio/stremio-icons@5.15.0':
+    resolution: {integrity: sha512-UaYBgpJBaHZOPLhfZkAIzf99Xy62mxvEKOmeOeNmsSCSc05O05/FXihbA3zKefZBKN6cOy8uWBRGsCrXryV4zg==}
 
   '@stremio/stremio-video@0.0.93':
     resolution: {integrity: sha512-/R6rHh/lekHK4ZjCeMb4O27iOXQo36jek0kfzbbpYw/3yXf9yWxX+LWK5hajBFeZWitOm8GMSnDlkb31LIeIeg==}
@@ -6495,7 +6495,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.24.1
 
-  '@stremio/stremio-icons@5.14.0': {}
+  '@stremio/stremio-icons@5.15.0': {}
 
   '@stremio/stremio-video@0.0.93':
     dependencies:

--- a/src/routes/Player/ControlBar/ControlBar.js
+++ b/src/routes/Player/ControlBar/ControlBar.js
@@ -12,10 +12,10 @@ const styles = require('./styles');
 const { useBinaryState, usePlatform } = require('stremio/common');
 const { t } = require('i18next');
 
-const VIDEO_SCALE_RATIOS = {
-    contain: '16:9',
-    cover: '4:3',
-    fill: '1:1'
+const VIDEO_SCALE_ICONS = {
+    contain: 'video-scale-fit',
+    cover: 'video-scale-crop',
+    fill: 'video-scale-stretch'
 };
 
 const ControlBar = React.forwardRef(({
@@ -205,12 +205,7 @@ const ControlBar = React.forwardRef(({
                             null
                     }
                     <Button className={classnames(styles['control-bar-button'], { 'disabled': videoScale === null })} title={videoScaleLabel} tabIndex={-1} onClick={onVideoScaleChanged}>
-                        <svg className={styles['icon']} viewBox={'0 0 512 512'} aria-hidden={true}>
-                            <rect x={'48'} y={'100'} width={'416'} height={'312'} rx={'40'} fill={'none'} stroke={'currentColor'} strokeWidth={'32'} />
-                            <text className={styles['video-scale-ratio']} x={'256'} y={'256'} fill={'currentColor'} fontWeight={'600'} textAnchor={'middle'} dominantBaseline={'central'}>
-                                {VIDEO_SCALE_RATIOS[videoScale || 'contain']}
-                            </text>
-                        </svg>
+                        <Icon className={styles['icon']} name={VIDEO_SCALE_ICONS[videoScale || 'contain']} />
                     </Button>
                     <Button className={classnames(styles['control-bar-button'], { 'disabled': !stream })} tabIndex={-1} onMouseDown={onOptionsButtonMouseDown} onClick={onToggleOptionsMenu}>
                         <Icon className={styles['icon']} name={'more-horizontal'} />

--- a/src/routes/Player/ControlBar/ControlBar.js
+++ b/src/routes/Player/ControlBar/ControlBar.js
@@ -12,6 +12,12 @@ const styles = require('./styles');
 const { useBinaryState, usePlatform } = require('stremio/common');
 const { t } = require('i18next');
 
+const VIDEO_SCALE_RATIOS = {
+    contain: '16:9',
+    cover: '4:3',
+    fill: '1:1'
+};
+
 const ControlBar = React.forwardRef(({
     className,
     paused,
@@ -199,7 +205,12 @@ const ControlBar = React.forwardRef(({
                             null
                     }
                     <Button className={classnames(styles['control-bar-button'], { 'disabled': videoScale === null })} title={videoScaleLabel} tabIndex={-1} onClick={onVideoScaleChanged}>
-                        <Icon className={styles['icon']} name={'aspect-ratio'} />
+                        <svg className={styles['icon']} viewBox={'0 0 512 512'} aria-hidden={true}>
+                            <rect x={'48'} y={'100'} width={'416'} height={'312'} rx={'40'} fill={'none'} stroke={'currentColor'} strokeWidth={'32'} />
+                            <text className={styles['video-scale-ratio']} x={'256'} y={'256'} fill={'currentColor'} fontWeight={'600'} textAnchor={'middle'} dominantBaseline={'central'}>
+                                {VIDEO_SCALE_RATIOS[videoScale || 'contain']}
+                            </text>
+                        </svg>
                     </Button>
                     <Button className={classnames(styles['control-bar-button'], { 'disabled': !stream })} tabIndex={-1} onMouseDown={onOptionsButtonMouseDown} onClick={onToggleOptionsMenu}>
                         <Icon className={styles['icon']} name={'more-horizontal'} />

--- a/src/routes/Player/ControlBar/styles.less
+++ b/src/routes/Player/ControlBar/styles.less
@@ -46,6 +46,10 @@
                 color: var(--primary-foreground-color);
                 transition: transform 100ms ease;
             }
+
+            .video-scale-ratio {
+                font-size: 9.375rem;
+            }
         }
 
         .volume-slider {

--- a/src/routes/Player/ControlBar/styles.less
+++ b/src/routes/Player/ControlBar/styles.less
@@ -46,10 +46,6 @@
                 color: var(--primary-foreground-color);
                 transition: transform 100ms ease;
             }
-
-            .video-scale-ratio {
-                font-size: 9.375rem;
-            }
         }
 
         .volume-slider {


### PR DESCRIPTION
Replaces the static 4:3 icon with a value for each scale mode: 16:9 for Fit, 4:3 for Crop, and 1:1 for Stretch.