### PR TITLE
Player: Fine tune subtitles delay controls

### DIFF
--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -118,7 +118,9 @@ const SubtitlesMenu = React.memo(React.forwardRef((props, ref) => {
         if (typeof props.selectedExtraSubtitlesTrackId === 'string') {
             if (props.extraSubtitlesDelay !== null && !isNaN(props.extraSubtitlesDelay)) {
                 if (typeof props.onExtraSubtitlesDelayChanged === 'function') {
-                    props.onExtraSubtitlesDelayChanged(Math.round(value * 1000));
+                    const delay = Math.round(value * 1000);
+                    const snappedDelay = delay > props.extraSubtitlesDelay ? Math.floor(delay / 100) * 100 : Math.ceil(delay / 100) * 100;
+                    props.onExtraSubtitlesDelayChanged(snappedDelay);
                 }
             }
         }

--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -10,6 +10,7 @@ const styles = require('./styles');
 const { t } = require('i18next');
 const { default: Stepper } = require('./Stepper');
 const { default: SubtitleVariant } = require('./SubtitleVariant');
+const { snapSubtitleDelay, SUBTITLES_DELAY_STEP_MS } = require('../subtitleDelay');
 
 const ORIGIN_PRIORITIES = [
     'LOCAL',
@@ -119,8 +120,7 @@ const SubtitlesMenu = React.memo(React.forwardRef((props, ref) => {
             if (props.extraSubtitlesDelay !== null && !isNaN(props.extraSubtitlesDelay)) {
                 if (typeof props.onExtraSubtitlesDelayChanged === 'function') {
                     const delay = Math.round(value * 1000);
-                    const snappedDelay = delay > props.extraSubtitlesDelay ? Math.floor(delay / 100) * 100 : Math.ceil(delay / 100) * 100;
-                    props.onExtraSubtitlesDelayChanged(snappedDelay);
+                    props.onExtraSubtitlesDelayChanged(snapSubtitleDelay(delay, delay - props.extraSubtitlesDelay));
                 }
             }
         }
@@ -216,7 +216,7 @@ const SubtitlesMenu = React.memo(React.forwardRef((props, ref) => {
                         label={'DELAY'}
                         value={props.extraSubtitlesDelay / 1000}
                         unit={'s'}
-                        step={0.1}
+                        step={SUBTITLES_DELAY_STEP_MS / 1000}
                         disabled={props.extraSubtitlesDelay === null}
                         onChange={onSubtitlesDelayChanged}
                     />

--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -118,7 +118,7 @@ const SubtitlesMenu = React.memo(React.forwardRef((props, ref) => {
         if (typeof props.selectedExtraSubtitlesTrackId === 'string') {
             if (props.extraSubtitlesDelay !== null && !isNaN(props.extraSubtitlesDelay)) {
                 if (typeof props.onExtraSubtitlesDelayChanged === 'function') {
-                    props.onExtraSubtitlesDelayChanged(value * 1000);
+                    props.onExtraSubtitlesDelayChanged(Math.round(value * 1000));
                 }
             }
         }
@@ -214,7 +214,7 @@ const SubtitlesMenu = React.memo(React.forwardRef((props, ref) => {
                         label={'DELAY'}
                         value={props.extraSubtitlesDelay / 1000}
                         unit={'s'}
-                        step={0.25}
+                        step={0.1}
                         disabled={props.extraSubtitlesDelay === null}
                         onChange={onSubtitlesDelayChanged}
                     />

--- a/src/routes/Player/subtitleDelay.ts
+++ b/src/routes/Player/subtitleDelay.ts
@@ -1,0 +1,11 @@
+const SUBTITLES_DELAY_STEP_MS = 100;
+
+const snapSubtitleDelay = (delay: number, direction: number) => {
+    const snap = direction > 0 ? Math.floor : Math.ceil;
+    return snap(delay / SUBTITLES_DELAY_STEP_MS) * SUBTITLES_DELAY_STEP_MS;
+};
+
+export {
+    SUBTITLES_DELAY_STEP_MS,
+    snapSubtitleDelay,
+};

--- a/src/routes/Player/subtitleDelay.ts
+++ b/src/routes/Player/subtitleDelay.ts
@@ -1,3 +1,5 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
 const SUBTITLES_DELAY_STEP_MS = 100;
 
 const snapSubtitleDelay = (delay: number, direction: number) => {

--- a/src/routes/Player/useSubtitles.ts
+++ b/src/routes/Player/useSubtitles.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CONSTANTS, languages, onFileDrop, onShortcut, useToast } from 'stremio/common';
+import { snapSubtitleDelay, SUBTITLES_DELAY_STEP_MS } from './subtitleDelay';
 
 const withFallbackLabels = (tracks?: SubtitleTrack[] | null): SubtitleTrack[] => {
     if (!Array.isArray(tracks)) {
@@ -282,11 +283,13 @@ const useSubtitles = ({
     }, [streamStateChanged, video]);
 
     const increaseDelay = useCallback(() => {
-        changeDelay(Math.floor((video.state.extraSubtitlesDelay ?? 0) / 100) * 100 + 100);
+        const delay = (video.state.extraSubtitlesDelay ?? 0) + SUBTITLES_DELAY_STEP_MS;
+        changeDelay(snapSubtitleDelay(delay, 1));
     }, [changeDelay, video.state.extraSubtitlesDelay]);
 
     const decreaseDelay = useCallback(() => {
-        changeDelay(Math.ceil((video.state.extraSubtitlesDelay ?? 0) / 100) * 100 - 100);
+        const delay = (video.state.extraSubtitlesDelay ?? 0) - SUBTITLES_DELAY_STEP_MS;
+        changeDelay(snapSubtitleDelay(delay, -1));
     }, [changeDelay, video.state.extraSubtitlesDelay]);
 
     const changeSize = useCallback((size: number) => {

--- a/src/routes/Player/useSubtitles.ts
+++ b/src/routes/Player/useSubtitles.ts
@@ -282,11 +282,11 @@ const useSubtitles = ({
     }, [streamStateChanged, video]);
 
     const increaseDelay = useCallback(() => {
-        changeDelay((video.state.extraSubtitlesDelay ?? 0) + 250);
+        changeDelay((video.state.extraSubtitlesDelay ?? 0) + 100);
     }, [changeDelay, video.state.extraSubtitlesDelay]);
 
     const decreaseDelay = useCallback(() => {
-        changeDelay((video.state.extraSubtitlesDelay ?? 0) - 250);
+        changeDelay((video.state.extraSubtitlesDelay ?? 0) - 100);
     }, [changeDelay, video.state.extraSubtitlesDelay]);
 
     const changeSize = useCallback((size: number) => {

--- a/src/routes/Player/useSubtitles.ts
+++ b/src/routes/Player/useSubtitles.ts
@@ -282,11 +282,11 @@ const useSubtitles = ({
     }, [streamStateChanged, video]);
 
     const increaseDelay = useCallback(() => {
-        changeDelay((video.state.extraSubtitlesDelay ?? 0) + 100);
+        changeDelay(Math.floor((video.state.extraSubtitlesDelay ?? 0) / 100) * 100 + 100);
     }, [changeDelay, video.state.extraSubtitlesDelay]);
 
     const decreaseDelay = useCallback(() => {
-        changeDelay((video.state.extraSubtitlesDelay ?? 0) - 100);
+        changeDelay(Math.ceil((video.state.extraSubtitlesDelay ?? 0) / 100) * 100 - 100);
     }, [changeDelay, video.state.extraSubtitlesDelay]);
 
     const changeSize = useCallback((size: number) => {


### PR DESCRIPTION
## Summary

- Change subtitle delay controls from 250ms to 100ms.
- Keep menu and `G`/`H` shortcut increments consistent.
- Use one `SUBTITLES_DELAY_STEP_MS` constant for millisecond logic and the stepper's seconds value.
- Use one directional snapping helper for menu and keyboard adjustments.
- Snap existing off-grid values only when the user adjusts them, so a 50ms remainder can return to zero or move onto the 100ms grid.

## Context

Related to [Stremio/stremio-features#1901](https://github.com/Stremio/stremio-features/issues/1901).

#1398 is stacked on this PR so its held-key path can use the same 100ms grid and snapping helper. This PR should be reviewed and merged first.

## Verification

- `npm run lint`
- `npm test -- --runInBand` (70 tests)
- `npm run build` (two existing bundle-size warnings)
- Positive and negative grid arithmetic checks
- Local playback UAT passed with #1398