### PR TITLE
feat(player): add cue-based subtitle sync

### DIFF
--- a/src/common/Shortcuts/Shortcuts.tsx
+++ b/src/common/Shortcuts/Shortcuts.tsx
@@ -47,7 +47,9 @@ const ShortcutsProvider = ({ children, onShortcut }: Props) => {
             lastRepeatTime.current.set(repeatKey, now);
         }
 
-        SHORTCUTS.forEach(({ name, combos }) => combos.forEach((keys) => {
+        SHORTCUTS.forEach(({ name, combos, repeat = true }) => combos.forEach((keys) => {
+            if (event.repeat && !repeat) return;
+
             const modifers = (keys.includes('Ctrl') === ctrlKey)
                 && (keys.includes('Shift') === shiftKey)
                 && !altKey

--- a/src/common/Shortcuts/shortcuts.json
+++ b/src/common/Shortcuts/shortcuts.json
@@ -75,6 +75,18 @@
                 "combos": [["G"], ["H"]]
             },
             {
+                "name": "subtitlesSyncAudio",
+                "label": "SUBTITLES_LIVE_SYNC_AUDIO_HEARD",
+                "combos": [["Shift", "H"]],
+                "repeat": false
+            },
+            {
+                "name": "subtitlesSyncSubtitle",
+                "label": "SUBTITLES_LIVE_SYNC_SUBTITLE_SEEN",
+                "combos": [["Shift", "J"]],
+                "repeat": false
+            },
+            {
                 "name": "speed",
                 "label": "SETTINGS_SHORTCUT_PLAYBACK_SPEED",
                 "combos": [["["], ["]"]]

--- a/src/common/Shortcuts/types.d.ts
+++ b/src/common/Shortcuts/types.d.ts
@@ -2,6 +2,7 @@ type Shortcut = {
     name: string,
     label: string,
     combos: string[][],
+    repeat?: boolean,
 };
 
 type ShortcutGroup = {

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -163,12 +163,14 @@ const Player = () => {
         extraSubtitleTracks,
         selectedExtraSubtitleTrackId,
         subtitlesMenuProps,
+        cancelSubtitleSync,
     } = useSubtitles({
         player,
         video,
         settings,
         streamStateChanged,
         subtitlePreferenceChanged,
+        seeking,
         menusOpen,
         closeMenus,
         closeSubtitlesMenu,
@@ -264,9 +266,10 @@ const Player = () => {
     }, []);
 
     const commitSeek = React.useCallback((time) => {
+        cancelSubtitleSync();
         video.setTime(time);
         seek(time, video.state.duration, video.state.manifest?.name);
-    }, [video.state.duration, video.state.manifest]);
+    }, [cancelSubtitleSync, video.state.duration, video.state.manifest]);
     const {
         time: keyboardSeekTime,
         seekBy: seekByKeyboard,

--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -6,6 +6,7 @@ const classnames = require('classnames');
 const { languages } = require('stremio/common');
 const { SUBTITLES_SIZES, DEFAULT_SUBTITLES_LANGUAGE, LOCAL_SUBTITLES_LANGUAGE } = require('stremio/common/CONSTANTS');
 const { Button } = require('stremio/components');
+const { default: Icon } = require('@stremio/stremio-icons/react');
 const styles = require('./styles');
 const { t } = require('i18next');
 const { default: Stepper } = require('./Stepper');
@@ -79,6 +80,10 @@ const SubtitlesMenu = React.memo(React.forwardRef((props, ref) => {
         const tracks = allSubtitles.filter(({ lang }) => lang === selectedSubtitlesLanguage);
         return sortByValues(tracks, ORIGIN_PRIORITIES);
     }, [allSubtitles, selectedSubtitlesLanguage]);
+    const subtitleSyncResetDisabled = typeof props.selectedExtraSubtitlesTrackId !== 'string' ||
+        props.extraSubtitlesDelay === null ||
+        isNaN(props.extraSubtitlesDelay) ||
+        (props.extraSubtitlesDelay === 0 && props.subtitleSyncMark === null);
     const onMouseDown = React.useCallback((event) => {
         event.nativeEvent.subtitlesMenuClosePrevented = true;
     }, []);
@@ -218,6 +223,48 @@ const SubtitlesMenu = React.memo(React.forwardRef((props, ref) => {
                         disabled={props.extraSubtitlesDelay === null}
                         onChange={onSubtitlesDelayChanged}
                     />
+                    <div className={styles['live-sync']}>
+                        <div className={styles['live-sync-header']}>
+                            <div className={styles['live-sync-label']}>{t('SUBTITLES_LIVE_SYNC_SHORT')}</div>
+                            <Button
+                                className={classnames(styles['live-sync-reset'], { 'disabled': subtitleSyncResetDisabled })}
+                                title={t('SUBTITLES_LIVE_SYNC_RESET')}
+                                aria-label={t('SUBTITLES_LIVE_SYNC_RESET')}
+                                disabled={subtitleSyncResetDisabled}
+                                onClick={props.onSubtitleSyncReset}
+                            >
+                                <Icon className={styles['live-sync-reset-icon']} name={'reset'} />
+                            </Button>
+                        </div>
+                        <div className={styles['live-sync-buttons']}>
+                            <Button
+                                className={classnames(styles['live-sync-button'], {
+                                    'disabled': !props.subtitleSyncAvailable,
+                                    [styles['selected']]: props.subtitleSyncMark === 'audio',
+                                })}
+                                role={'button'}
+                                aria-pressed={props.subtitleSyncMark === 'audio'}
+                                disabled={!props.subtitleSyncAvailable}
+                                onClick={props.onSubtitleSyncAudioMarked}
+                            >
+                                <Icon className={styles['live-sync-button-icon']} name={'volume-high'} />
+                                <span className={styles['live-sync-button-label']}>{t('SUBTITLES_LIVE_SYNC_AUDIO_HEARD')}</span>
+                            </Button>
+                            <Button
+                                className={classnames(styles['live-sync-button'], {
+                                    'disabled': !props.subtitleSyncAvailable,
+                                    [styles['selected']]: props.subtitleSyncMark === 'subtitle',
+                                })}
+                                role={'button'}
+                                aria-pressed={props.subtitleSyncMark === 'subtitle'}
+                                disabled={!props.subtitleSyncAvailable}
+                                onClick={props.onSubtitleSyncSubtitleMarked}
+                            >
+                                <Icon className={styles['live-sync-button-icon']} name={'subtitles'} />
+                                <span className={styles['live-sync-button-label']}>{t('SUBTITLES_LIVE_SYNC_SUBTITLE_SEEN')}</span>
+                            </Button>
+                        </div>
+                    </div>
                     <Stepper
                         className={styles['stepper']}
                         label={'SIZE'}
@@ -277,13 +324,18 @@ SubtitlesMenu.propTypes = {
     extraSubtitlesDelay: PropTypes.number,
     extraSubtitlesSize: PropTypes.number,
     assSubtitlesStylingActive: PropTypes.bool,
+    subtitleSyncAvailable: PropTypes.bool,
+    subtitleSyncMark: PropTypes.oneOf(['audio', 'subtitle']),
     onSubtitlesTrackSelected: PropTypes.func,
     onExtraSubtitlesTrackSelected: PropTypes.func,
     onSubtitlesOffsetChanged: PropTypes.func,
     onSubtitlesSizeChanged: PropTypes.func,
     onExtraSubtitlesOffsetChanged: PropTypes.func,
     onExtraSubtitlesDelayChanged: PropTypes.func,
-    onExtraSubtitlesSizeChanged: PropTypes.func
+    onExtraSubtitlesSizeChanged: PropTypes.func,
+    onSubtitleSyncAudioMarked: PropTypes.func,
+    onSubtitleSyncSubtitleMarked: PropTypes.func,
+    onSubtitleSyncReset: PropTypes.func
 };
 
 module.exports = SubtitlesMenu;

--- a/src/routes/Player/SubtitlesMenu/styles.less
+++ b/src/routes/Player/SubtitlesMenu/styles.less
@@ -91,6 +91,108 @@
             flex: 1;
         }
 
+        .live-sync {
+            padding: 0 1.5rem 1rem;
+
+            .live-sync-header {
+                display: flex;
+                align-items: center;
+                min-height: 2rem;
+                margin-bottom: 0.5rem;
+
+                .live-sync-label {
+                    flex: 1;
+                    color: var(--primary-foreground-color);
+                    opacity: 0.6;
+                }
+
+                .live-sync-reset {
+                    flex: none;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: 2rem;
+                    height: 2rem;
+                    padding: 0.45rem;
+                    border-radius: 100%;
+                    transition: background-color 150ms ease, opacity 150ms ease;
+
+                    &:hover {
+                        background-color: var(--overlay-color);
+                    }
+
+                    &:global(.disabled) {
+                        opacity: 0.4;
+                    }
+
+                    .live-sync-reset-icon {
+                        display: block;
+                        width: 100%;
+                        height: 100%;
+                        color: var(--primary-foreground-color);
+                    }
+                }
+            }
+
+            .live-sync-buttons {
+                display: grid;
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                gap: 0.5rem;
+
+                .live-sync-button {
+                    min-width: 0;
+                    height: 4.5rem;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    justify-content: center;
+                    gap: 0.35rem;
+                    padding: 0.4rem 0.5rem;
+                    border-radius: var(--border-radius);
+                    background-color: var(--overlay-color);
+                    color: var(--primary-foreground-color);
+                    font-size: 0.9rem;
+                    font-weight: 500;
+                    line-height: 1.2;
+                    transition: box-shadow 150ms ease, color 150ms ease;
+
+                    &.selected {
+                        box-shadow: inset 0 0 0 0.15rem var(--secondary-accent-color);
+
+                        .live-sync-button-icon {
+                            color: var(--secondary-accent-color);
+                            opacity: 1;
+                        }
+                    }
+
+                    &:global(.disabled) {
+                        opacity: 0.4;
+                    }
+
+                    .live-sync-button-icon {
+                        flex: none;
+                        width: 1rem;
+                        height: 1rem;
+                        color: var(--primary-foreground-color);
+                        opacity: 0.65;
+                        transition: color 150ms ease, opacity 150ms ease;
+                    }
+
+                    .live-sync-button-label {
+                        flex: none;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        width: 4.5rem;
+                        height: 2.4em;
+                        max-width: 100%;
+                        text-align: center;
+                        overflow: hidden;
+                    }
+                }
+            }
+        }
+
         .stepper {
             padding: 0 1.5rem 1rem;
         }

--- a/src/routes/Player/useSubtitles.d.ts
+++ b/src/routes/Player/useSubtitles.d.ts
@@ -22,6 +22,9 @@ type SelectedSubtitleTrack = {
 
 type VideoSubtitleState = {
     stream: unknown | null,
+    paused: boolean | null,
+    buffering: boolean | null,
+    playbackSpeed: number | null,
     subtitlesTracks: SubtitleTrack[],
     selectedSubtitlesTrackId: string | null,
     subtitlesOffset: number | null,
@@ -60,6 +63,7 @@ type UseSubtitlesArgs = {
     settings: Settings,
     streamStateChanged: (state: Partial<StreamState>) => void,
     subtitlePreferenceChanged: (preference: SubtitlePreference) => void,
+    seeking: boolean,
     menusOpen: boolean,
     closeMenus: () => void,
     closeSubtitlesMenu: () => void,
@@ -79,6 +83,8 @@ type SubtitlesMenuProps = {
     extraSubtitlesDelay: number | null,
     extraSubtitlesSize: number | null,
     assSubtitlesStylingActive: boolean,
+    subtitleSyncAvailable: boolean,
+    subtitleSyncMark: 'audio' | 'subtitle' | null,
     onSubtitlesTrackSelected: (track: SubtitleTrack | null) => void,
     onExtraSubtitlesTrackSelected: (track: SubtitleTrack | null) => void,
     onSubtitlesOffsetChanged: (offset: number) => void,
@@ -86,6 +92,9 @@ type SubtitlesMenuProps = {
     onExtraSubtitlesOffsetChanged: (offset: number) => void,
     onExtraSubtitlesDelayChanged: (delay: number) => void,
     onExtraSubtitlesSizeChanged: (size: number) => void,
+    onSubtitleSyncAudioMarked: () => void,
+    onSubtitleSyncSubtitleMarked: () => void,
+    onSubtitleSyncReset: () => void,
 };
 
 type UseSubtitlesResult = {
@@ -94,4 +103,5 @@ type UseSubtitlesResult = {
     extraSubtitleTracks: SubtitleTrack[],
     selectedExtraSubtitleTrackId: string | null,
     subtitlesMenuProps: SubtitlesMenuProps,
+    cancelSubtitleSync: () => void,
 };

--- a/src/routes/Player/useSubtitles.ts
+++ b/src/routes/Player/useSubtitles.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2017-2026 Smart code 203358507
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CONSTANTS, languages, onFileDrop, onShortcut, useToast } from 'stremio/common';
 
@@ -54,6 +54,16 @@ type ResolvedSubtitleCandidate = {
     rank: number,
     track: SubtitleTrack,
 };
+
+type SubtitleSync = {
+    audioHeardAt: number | null,
+    subtitleSeenAt: number | null,
+    baseDelay: number,
+    playbackSpeed: number,
+    trackId: string,
+};
+
+type SubtitleSyncMark = 'audio' | 'subtitle';
 
 const candidateMatchesTrack = (
     candidate: SubtitleCandidate,
@@ -164,6 +174,7 @@ const useSubtitles = ({
     settings,
     streamStateChanged,
     subtitlePreferenceChanged,
+    seeking,
     menusOpen,
     closeMenus,
     closeSubtitlesMenu,
@@ -176,9 +187,16 @@ const useSubtitles = ({
     const trackSelectionLocked = useRef(false);
     const appliedTrack = useRef<{ id: string, source: SubtitleSource } | null>(null);
     const lastSelectedTrack = useRef<SelectedSubtitleTrack | null>(null);
+    const subtitleSync = useRef<SubtitleSync | null>(null);
+    const [subtitleSyncMark, setSubtitleSyncMark] = useState<SubtitleSyncMark | null>(null);
 
     videoRef.current = video;
     settingsRef.current = settings;
+
+    const cancelSubtitleSync = useCallback(() => {
+        subtitleSync.current = null;
+        setSubtitleSyncMark(null);
+    }, []);
 
     const streamSubtitles = useMemo(() => {
         return withFallbackLabels(player.selected?.stream.subtitles);
@@ -277,9 +295,70 @@ const useSubtitles = ({
     }, [disableSubtitles, rememberTrack, video]);
 
     const changeDelay = useCallback((delay: number) => {
+        cancelSubtitleSync();
         video.setSubtitlesDelay(delay);
         streamStateChanged({ subtitleDelay: delay });
-    }, [streamStateChanged, video]);
+    }, [cancelSubtitleSync, streamStateChanged, video]);
+
+    const subtitleSyncAvailable = typeof video.state.selectedExtraSubtitlesTrackId === 'string' &&
+        typeof video.state.extraSubtitlesDelay === 'number' &&
+        Number.isFinite(video.state.extraSubtitlesDelay) &&
+        video.state.paused === false &&
+        video.state.buffering === false &&
+        typeof video.state.playbackSpeed === 'number' &&
+        Number.isFinite(video.state.playbackSpeed) &&
+        video.state.playbackSpeed > 0 &&
+        !seeking;
+
+    const markSubtitleSync = useCallback((mark: SubtitleSyncMark) => {
+        if (!subtitleSyncAvailable) return;
+
+        const baseDelay = video.state.extraSubtitlesDelay as number;
+        const playbackSpeed = video.state.playbackSpeed as number;
+        const trackId = video.state.selectedExtraSubtitlesTrackId as string;
+        const current = subtitleSync.current;
+        const sync = current &&
+            current.baseDelay === baseDelay &&
+            current.playbackSpeed === playbackSpeed &&
+            current.trackId === trackId ?
+            current
+            :
+            {
+                audioHeardAt: null,
+                subtitleSeenAt: null,
+                baseDelay,
+                playbackSpeed,
+                trackId,
+            };
+        const markedAt = performance.now();
+        const next = mark === 'audio' ?
+            { ...sync, audioHeardAt: markedAt }
+            :
+            { ...sync, subtitleSeenAt: markedAt };
+
+        if (next.audioHeardAt !== null && next.subtitleSeenAt !== null) {
+            changeDelay(Math.round(
+                next.baseDelay +
+                (next.audioHeardAt - next.subtitleSeenAt) * next.playbackSpeed,
+            ));
+            return;
+        }
+
+        subtitleSync.current = next;
+        setSubtitleSyncMark(mark);
+    }, [changeDelay, subtitleSyncAvailable, video.state.extraSubtitlesDelay, video.state.playbackSpeed, video.state.selectedExtraSubtitlesTrackId]);
+
+    const markSubtitleSyncAudio = useCallback(() => {
+        markSubtitleSync('audio');
+    }, [markSubtitleSync]);
+
+    const markSubtitleSyncSubtitle = useCallback(() => {
+        markSubtitleSync('subtitle');
+    }, [markSubtitleSync]);
+
+    const resetSubtitleSync = useCallback(() => {
+        changeDelay(0);
+    }, [changeDelay]);
 
     const increaseDelay = useCallback(() => {
         changeDelay((video.state.extraSubtitlesDelay ?? 0) + 250);
@@ -310,6 +389,20 @@ const useSubtitles = ({
     onFileDrop(CONSTANTS.SUPPORTED_LOCAL_SUBTITLES, (file: File, buffer: ArrayBuffer) => {
         videoRef.current.addLocalSubtitles(file.name, buffer);
     });
+
+    useEffect(() => {
+        cancelSubtitleSync();
+    }, [
+        cancelSubtitleSync,
+        seeking,
+        video.state.buffering,
+        video.state.extraSubtitlesDelay,
+        video.state.paused,
+        video.state.playbackSpeed,
+        video.state.selectedExtraSubtitlesTrackId,
+        video.state.selectedSubtitlesTrackId,
+        video.state.stream,
+    ]);
 
     useEffect(() => {
         if (video.state.stream !== null) {
@@ -481,6 +574,10 @@ const useSubtitles = ({
         combo === 1 ? increaseDelay() : decreaseDelay();
     }, [increaseDelay, decreaseDelay], !menusOpen);
 
+    onShortcut('subtitlesSyncAudio', markSubtitleSyncAudio, [markSubtitleSyncAudio], !menusOpen && subtitleSyncAvailable);
+
+    onShortcut('subtitlesSyncSubtitle', markSubtitleSyncSubtitle, [markSubtitleSyncSubtitle], !menusOpen && subtitleSyncAvailable);
+
     onShortcut('subtitlesSize', (combo) => {
         combo === 1 ? updateSize(1) : updateSize(-1);
     }, [updateSize], !menusOpen);
@@ -561,6 +658,8 @@ const useSubtitles = ({
         extraSubtitlesDelay: video.state.extraSubtitlesDelay,
         extraSubtitlesSize: video.state.extraSubtitlesSize,
         assSubtitlesStylingActive: video.state.assSubtitlesStylingActive,
+        subtitleSyncAvailable,
+        subtitleSyncMark,
         onSubtitlesTrackSelected: selectEmbeddedTrack,
         onExtraSubtitlesTrackSelected: selectExtraTrack,
         onSubtitlesOffsetChanged: changeOffset,
@@ -568,10 +667,16 @@ const useSubtitles = ({
         onExtraSubtitlesOffsetChanged: changeOffset,
         onExtraSubtitlesDelayChanged: changeDelay,
         onExtraSubtitlesSizeChanged: changeSize,
+        onSubtitleSyncAudioMarked: markSubtitleSyncAudio,
+        onSubtitleSyncSubtitleMarked: markSubtitleSyncSubtitle,
+        onSubtitleSyncReset: resetSubtitleSync,
     }), [
         changeDelay,
         changeOffset,
         changeSize,
+        markSubtitleSyncAudio,
+        markSubtitleSyncSubtitle,
+        resetSubtitleSync,
         selectEmbeddedTrack,
         selectExtraTrack,
         settings.interfaceLanguage,
@@ -586,6 +691,8 @@ const useSubtitles = ({
         video.state.subtitlesOffset,
         video.state.subtitlesSize,
         video.state.subtitlesTracks,
+        subtitleSyncAvailable,
+        subtitleSyncMark,
     ]);
 
     return {
@@ -594,6 +701,7 @@ const useSubtitles = ({
         extraSubtitleTracks: video.state.extraSubtitlesTracks,
         selectedExtraSubtitleTrackId: video.state.selectedExtraSubtitlesTrackId,
         subtitlesMenuProps: menuProps,
+        cancelSubtitleSync,
     };
 };
 


### PR DESCRIPTION
## Summary

- Add a compact Live Sync control for external subtitles.
- Let users mark `Audio heard` and `Subtitle seen` in either order, then apply the calculated constant offset automatically.
- Add `Shift+H` and `Shift+J` shortcuts, a reset action, and clear captured-marker styling.
- Preserve the existing subtitle delay path and stream-state persistence.

## Behavior

- Capture markers only during active playback with an available external subtitle.
- Use monotonic timestamps and account for playback speed.
- Cancel incomplete marker pairs on pause, buffering, seek, speed change, stream change, subtitle change, or manual delay adjustment.
- Prevent held cue-sync shortcuts from repeating.
- Keep the existing subtitle menu layout and present both actions as centered two-line controls.

## Scope

This corrects constant offset for external subtitles. It does not change embedded-subtitle timing or correct FPS drift, edited cuts, or piecewise timing differences.

## Translation dependency

Depends on [Stremio/stremio-translations#1092](https://github.com/Stremio/stremio-translations/pull/1092).

The feature was developed and tested against the local translation checkout. No dependency on the contributor fork is committed. The translation PR should merge first; this branch will then pin its official upstream commit before being marked ready for review. Until then, a clean CI checkout may report the three new translation keys as missing.

## Verification

- Dedicated translation-key scan
- `npm run lint`
- `npm test -- --runInBand` (70 tests)
- `npm run build` (two existing bundle-size warnings)
- Manual UAT on Stremio Desktop for external-subtitle synchronization and the revised controls

## Related requests

- [Stremio/stremio-features#1901](https://github.com/Stremio/stremio-features/issues/1901)
- [Stremio/stremio-features#750](https://github.com/Stremio/stremio-features/issues/750)
- [Stremio/stremio-features#914](https://github.com/Stremio/stremio-features/issues/914)