### PR TITLE
Player: accelerate held subtitle delay adjustments

### DIFF
--- a/src/common/Shortcuts/Shortcuts.tsx
+++ b/src/common/Shortcuts/Shortcuts.tsx
@@ -5,7 +5,7 @@ import shortcuts from './shortcuts.json';
 const SHORTCUTS = shortcuts.map(({ shortcuts }) => shortcuts).flat();
 
 export type ShortcutName = string;
-export type ShortcutListener = (combo: number, key: string) => void;
+export type ShortcutListener = (combo: number, key: string, repeat: boolean) => void;
 
 interface ShortcutsContext {
     grouped: ShortcutGroup[],
@@ -60,7 +60,7 @@ const ShortcutsProvider = ({ children, onShortcut }: Props) => {
 
             if (modifers && keyMatched) {
                 const combo = combos.indexOf(keys);
-                listeners.current.get(name)?.forEach((listener) => listener(combo, key));
+                listeners.current.get(name)?.forEach((listener) => listener(combo, key, repeat));
 
                 onShortcut(name as ShortcutName, combo, key);
             }

--- a/src/routes/Player/SubtitlesMenu/Stepper/Stepper.tsx
+++ b/src/routes/Player/SubtitlesMenu/Stepper/Stepper.tsx
@@ -4,6 +4,11 @@ import classNames from 'classnames';
 import Icon from '@stremio/stremio-icons/react';
 import { Button } from 'stremio/components';
 import { useInterval, useTimeout } from 'stremio/common';
+import {
+    getSubtitleDelayStepMultiplier,
+    SUBTITLES_DELAY_REPEAT_DELAY_MS,
+    SUBTITLES_DELAY_REPEAT_INTERVAL_MS,
+} from '../../subtitleDelay';
 import styles from './Stepper.less';
 
 const clamp = (value: number, min?: number, max?: number) => {
@@ -21,16 +26,19 @@ type Props = {
     min?: number,
     max?: number,
     disabled?: boolean,
+    accelerate?: boolean,
     onChange: (value: number) => void,
 };
 
-const Stepper = ({ className, label, value, unit, step, min, max, disabled, onChange }: Props) => {
+const Stepper = ({ className, label, value, unit, step, min, max, disabled, accelerate = false, onChange }: Props) => {
     const { t } = useTranslation();
 
     const localValue = useRef(value);
+    const holdStartedAt = useRef(0);
+    const hasRepeated = useRef(false);
 
-    const interval = useInterval(100);
-    const timeout = useTimeout(250);
+    const interval = useInterval(SUBTITLES_DELAY_REPEAT_INTERVAL_MS);
+    const timeout = useTimeout(SUBTITLES_DELAY_REPEAT_DELAY_MS);
 
     const cancel = () => {
         interval.cancel();
@@ -51,27 +59,45 @@ const Stepper = ({ className, label, value, unit, step, min, max, disabled, onCh
 
     const updateValue = useCallback((delta: number) => {
         onChange(clamp(localValue.current + delta, min, max));
-    }, [onChange]);
+    }, [max, min, onChange]);
+
+    const startRepeating = useCallback((direction: number) => {
+        cancel();
+        holdStartedAt.current = performance.now();
+        hasRepeated.current = false;
+        let repeatValue = localValue.current;
+
+        timeout.start(() => interval.start(() => {
+            if (!accelerate) {
+                updateValue(direction * step);
+                return;
+            }
+
+            hasRepeated.current = true;
+            const heldFor = performance.now() - holdStartedAt.current;
+            const multiplier = getSubtitleDelayStepMultiplier(heldFor);
+            repeatValue = clamp(repeatValue + direction * step * multiplier, min, max);
+            onChange(repeatValue);
+        }));
+    }, [accelerate, max, min, onChange, step, updateValue]);
 
     const onDecrementMouseDown = useCallback(() => {
-        cancel();
-        timeout.start(() => interval.start(() => updateValue(-step)));
-    }, [updateValue]);
+        startRepeating(-1);
+    }, [startRepeating]);
 
     const onDecrementMouseUp = useCallback(() => {
         cancel();
-        updateValue(-step);
-    }, [updateValue]);
+        if (!accelerate || !hasRepeated.current) updateValue(-step);
+    }, [accelerate, step, updateValue]);
 
     const onIncrementMouseDown = useCallback(() => {
-        cancel();
-        timeout.start(() => interval.start(() => updateValue(step)));
-    }, [updateValue]);
+        startRepeating(1);
+    }, [startRepeating]);
 
     const onIncrementMouseUp = useCallback(() => {
         cancel();
-        updateValue(step);
-    }, [updateValue]);
+        if (!accelerate || !hasRepeated.current) updateValue(step);
+    }, [accelerate, step, updateValue]);
 
     useEffect(() => {
         localValue.current = value;

--- a/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
+++ b/src/routes/Player/SubtitlesMenu/SubtitlesMenu.js
@@ -212,6 +212,7 @@ const SubtitlesMenu = React.memo(React.forwardRef((props, ref) => {
                 <div className={styles['settings-header']}>{t('PLAYER_SUBTITLES_SETTINGS')}</div>
                 <div className={styles['settings-list']}>
                     <Stepper
+                        accelerate
                         className={styles['stepper']}
                         label={'DELAY'}
                         value={props.extraSubtitlesDelay / 1000}

--- a/src/routes/Player/subtitleDelay.ts
+++ b/src/routes/Player/subtitleDelay.ts
@@ -1,13 +1,24 @@
 // Copyright (C) 2017-2026 Smart code 203358507
 
 const SUBTITLES_DELAY_STEP_MS = 100;
+const SUBTITLES_DELAY_REPEAT_DELAY_MS = 250;
+const SUBTITLES_DELAY_REPEAT_INTERVAL_MS = 100;
+const INITIAL_STEP_MULTIPLIER = 3;
+const MAX_STEP_MULTIPLIER = 6;
 
 const snapSubtitleDelay = (delay: number, direction: number) => {
     const snap = direction > 0 ? Math.floor : Math.ceil;
     return snap(delay / SUBTITLES_DELAY_STEP_MS) * SUBTITLES_DELAY_STEP_MS;
 };
 
+const getSubtitleDelayStepMultiplier = (heldForMs: number) => {
+    return Math.min(Math.floor(heldForMs / 1000) + INITIAL_STEP_MULTIPLIER, MAX_STEP_MULTIPLIER);
+};
+
 export {
+    getSubtitleDelayStepMultiplier,
     SUBTITLES_DELAY_STEP_MS,
+    SUBTITLES_DELAY_REPEAT_DELAY_MS,
+    SUBTITLES_DELAY_REPEAT_INTERVAL_MS,
     snapSubtitleDelay,
 };

--- a/src/routes/Player/useSubtitles.ts
+++ b/src/routes/Player/useSubtitles.ts
@@ -2,8 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CONSTANTS, languages, useFileDropListener, useShortcut, useToast } from 'stremio/common';
-import { snapSubtitleDelay, SUBTITLES_DELAY_STEP_MS } from './subtitleDelay';
+import { CONSTANTS, languages, useFileDropListener, useInterval, useShortcut, useTimeout, useToast } from 'stremio/common';
+import {
+    getSubtitleDelayStepMultiplier,
+    snapSubtitleDelay,
+    SUBTITLES_DELAY_REPEAT_DELAY_MS,
+    SUBTITLES_DELAY_REPEAT_INTERVAL_MS,
+    SUBTITLES_DELAY_STEP_MS,
+} from './subtitleDelay';
 
 const withFallbackLabels = (tracks?: SubtitleTrack[] | null): SubtitleTrack[] => {
     if (!Array.isArray(tracks)) {
@@ -54,6 +60,14 @@ type ResolvedSubtitleCandidate = {
     source: SubtitleSource,
     rank: number,
     track: SubtitleTrack,
+};
+
+type SubtitleDelayHold = {
+    direction: number,
+    key: string,
+    repeated: boolean,
+    startedAt: number,
+    value: number,
 };
 
 const candidateMatchesTrack = (
@@ -178,6 +192,9 @@ const useSubtitles = ({
     const trackSelectionLocked = useRef(false);
     const appliedTrack = useRef<{ id: string, source: SubtitleSource } | null>(null);
     const lastSelectedTrack = useRef<SelectedSubtitleTrack | null>(null);
+    const subtitleDelayHold = useRef<SubtitleDelayHold | null>(null);
+    const subtitleDelayInterval = useInterval(SUBTITLES_DELAY_REPEAT_INTERVAL_MS);
+    const subtitleDelayTimeout = useTimeout(SUBTITLES_DELAY_REPEAT_DELAY_MS);
 
     videoRef.current = video;
     settingsRef.current = settings;
@@ -293,15 +310,60 @@ const useSubtitles = ({
         streamStateChanged({ subtitleDelay: delay });
     }, [streamStateChanged, setSubtitlesDelay]);
 
-    const increaseDelay = useCallback(() => {
-        const delay = (video.state.extraSubtitlesDelay ?? 0) + SUBTITLES_DELAY_STEP_MS;
-        changeDelay(snapSubtitleDelay(delay, 1));
-    }, [changeDelay, video.state.extraSubtitlesDelay]);
+    const finishSubtitleDelayHold = useCallback((applyStep: boolean) => {
+        const hold = subtitleDelayHold.current;
+        subtitleDelayInterval.cancel();
+        subtitleDelayTimeout.cancel();
+        subtitleDelayHold.current = null;
 
-    const decreaseDelay = useCallback(() => {
-        const delay = (video.state.extraSubtitlesDelay ?? 0) - SUBTITLES_DELAY_STEP_MS;
-        changeDelay(snapSubtitleDelay(delay, -1));
-    }, [changeDelay, video.state.extraSubtitlesDelay]);
+        if (applyStep && hold && !hold.repeated) {
+            const delay = hold.value + hold.direction * SUBTITLES_DELAY_STEP_MS;
+            changeDelay(snapSubtitleDelay(delay, hold.direction));
+        }
+    }, [changeDelay]);
+
+    const startSubtitleDelayHold = useCallback((combo: number, key: string, repeat: boolean) => {
+        if (repeat || subtitleDelayHold.current) return;
+
+        const hold = {
+            direction: combo === 1 ? 1 : -1,
+            key: key.toLowerCase(),
+            repeated: false,
+            startedAt: performance.now(),
+            value: videoRef.current.state.extraSubtitlesDelay ?? 0,
+        };
+        subtitleDelayHold.current = hold;
+
+        subtitleDelayTimeout.start(() => subtitleDelayInterval.start(() => {
+            if (subtitleDelayHold.current !== hold) return;
+
+            hold.repeated = true;
+            const multiplier = getSubtitleDelayStepMultiplier(performance.now() - hold.startedAt);
+            const delay = hold.value + hold.direction * SUBTITLES_DELAY_STEP_MS * multiplier;
+            hold.value = snapSubtitleDelay(delay, hold.direction);
+            changeDelay(hold.value);
+        }));
+    }, [changeDelay]);
+
+    useEffect(() => {
+        const onKeyUp = (event: KeyboardEvent) => {
+            if (event.key.toLowerCase() === subtitleDelayHold.current?.key) {
+                finishSubtitleDelayHold(true);
+            }
+        };
+        const onBlur = () => finishSubtitleDelayHold(false);
+
+        document.addEventListener('keyup', onKeyUp);
+        window.addEventListener('blur', onBlur);
+        return () => {
+            document.removeEventListener('keyup', onKeyUp);
+            window.removeEventListener('blur', onBlur);
+        };
+    }, [finishSubtitleDelayHold]);
+
+    useEffect(() => {
+        if (menusOpen) finishSubtitleDelayHold(false);
+    }, [finishSubtitleDelayHold, menusOpen]);
 
     const changeSize = useCallback((size: number) => {
         setSubtitlesSize(size);
@@ -502,9 +564,7 @@ const useSubtitles = ({
         };
     }, [applySubtitleStyle, t, toast, video.events]);
 
-    useShortcut('subtitlesDelay', useCallback((combo) => {
-        combo === 1 ? increaseDelay() : decreaseDelay();
-    }, [increaseDelay, decreaseDelay]), !menusOpen);
+    useShortcut('subtitlesDelay', startSubtitleDelayHold, !menusOpen);
 
     useShortcut('subtitlesSize', useCallback((combo) => {
         combo === 1 ? updateSize(1) : updateSize(-1);


### PR DESCRIPTION
## Summary

- Keep the repeat interval fixed and increase only the subtitle-delay step while the control is held.
- Use the same hold delay, repeat interval and elapsed-time multiplier for the on-screen controls and the `G` and `H` shortcuts.
- Keep a normal click or key press at one 100ms step.
- Snap off-grid values in the selected direction so an existing 50ms remainder can still reach zero.
- Apply no extra step when a held on-screen control is released.
- Cancel keyboard holds on key release, focus loss or opening a player menu.
- Leave subtitle size, vertical position and visual layout unchanged.

## Hold behavior

The first repeat starts after 250ms. Repeats remain fixed at 100ms.

| Hold duration | Delay step |
| --- | ---: |
| Under 1 second | 300ms |
| 1-2 seconds | 400ms |
| 2-3 seconds | 500ms |
| 3 seconds or longer | 600ms |

## Context

Follow-up to the hold-acceleration request in [#1395](https://github.com/Stremio/stremio-web/pull/1395#issuecomment-5423913628).

Related to [Stremio/stremio-features#1901](https://github.com/Stremio/stremio-features/issues/1901).

## Verification

- `npm run lint`
- `npm test` (70 tests)
- `npm run build` (two existing bundle-size warnings)
- `git diff --check`
- Local playback UAT passed with the merged #1395 behavior