### PR TITLE
[Enhancement]: Add release year and IMDb rating on hover (#1403)

### DIFF
--- a/src/components/MetaItem/MetaItem.js
+++ b/src/components/MetaItem/MetaItem.js
@@ -15,7 +15,7 @@ const { default: getMetaDetailsHref } = require('stremio/common/getMetaDetailsHr
 const { ICON_FOR_TYPE } = require('stremio/common/CONSTANTS');
 const styles = require('./styles');
 
-const MetaItem = React.memo(({ className, type, name, poster, posterShape, posterChangeCursor, progress, newVideos, options, deepLinks, href: customHref, dataset, optionOnSelect, onDismissClick, onPlayClick, watched, ...props }) => {
+const MetaItem = React.memo(({ className, type, name, poster, posterShape, posterChangeCursor, progress, newVideos, options, deepLinks, href: customHref, dataset, optionOnSelect, onDismissClick, onPlayClick, watched, releaseInfo, links, ...props }) => {
     const { t } = useTranslation();
     const platform = usePlatform();
     const [menuOpen, onMenuOpen, onMenuClose] = useBinaryState(false);
@@ -62,6 +62,15 @@ const MetaItem = React.memo(({ className, type, name, poster, posterShape, poste
     const renderMenuLabelContent = React.useCallback(() => (
         <Icon className={styles['icon']} name={'more-vertical'} />
     ), []);
+    const imdbRating = React.useMemo(() => {
+        if (Array.isArray(links)) {
+            const imdbLink = links.find((link) => link.category === 'imdb');
+            if (imdbLink && imdbLink.name) {
+                return imdbLink.name;
+            }
+        }
+        return null;
+    }, [links]);
     return (
         <Button title={name} href={href} {...filterInvalidDOMProps(props)} className={classnames(className, styles['meta-item-container'], styles['poster-shape-poster'], styles[`poster-shape-${posterShape}`], { 'active': menuOpen })} onClick={metaItemOnClick}>
             <div className={classnames(styles['poster-container'], { 'poster-change-cursor': posterChangeCursor })}>
@@ -105,6 +114,29 @@ const MetaItem = React.memo(({ className, type, name, poster, posterShape, poste
                         <div className={styles['progress-bar-layer']}>
                             <div className={styles['progress-bar']} style={{ width: `${progress}%` }} />
                             <div className={styles['progress-bar-background']} />
+                        </div>
+                        :
+                        null
+                }
+                {
+                    (typeof releaseInfo === 'string' && releaseInfo.length > 0) || imdbRating ?
+                        <div className={styles['info-layer']}>
+                            <div className={styles['info-layer-background']} />
+                            <div className={styles['info-layer-content']}>
+                                {
+                                    typeof releaseInfo === 'string' && releaseInfo.length > 0 ?
+                                        <div className={styles['release-info']}>{releaseInfo}</div>
+                                        : null
+                                }
+                                {
+                                    imdbRating ?
+                                        <div className={styles['imdb-rating']}>
+                                            <Icon className={styles['imdb-icon']} name={'imdb'} />
+                                            <span>{imdbRating}</span>
+                                        </div>
+                                        : null
+                                }
+                            </div>
                         </div>
                         :
                         null
@@ -179,7 +211,9 @@ MetaItem.propTypes = {
     onDismissClick: PropTypes.func,
     onPlayClick: PropTypes.func,
     onClick: PropTypes.func,
-    watched: PropTypes.bool
+    watched: PropTypes.bool,
+    releaseInfo: PropTypes.string,
+    links: PropTypes.array
 };
 
 module.exports = MetaItem;

--- a/src/components/MetaItem/styles.less
+++ b/src/components/MetaItem/styles.less
@@ -44,6 +44,11 @@
                     opacity: 1;
                 }
             }
+
+            .info-layer {
+                opacity: 1;
+                transform: translateY(0);
+            }
         }
 
         .title-bar-container {
@@ -252,6 +257,66 @@
             }
         }
 
+        .info-layer {
+            z-index: -2;
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            padding: 2.5rem 0.5rem 0.5rem 0.5rem;
+            opacity: 0;
+            transform: translateY(10px);
+            transition: all 0.2s ease-out;
+            pointer-events: none;
+
+            .info-layer-background {
+                position: absolute;
+                bottom: 0;
+                left: 0;
+                right: 0;
+                top: 0;
+                background: linear-gradient(to top, rgba(0,0,0,0.9) 0%, rgba(0,0,0,0.6) 60%, rgba(0,0,0,0) 100%);
+                z-index: -1;
+                border-bottom-left-radius: var(--border-radius);
+                border-bottom-right-radius: var(--border-radius);
+            }
+
+            .info-layer-content {
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+                justify-content: space-between;
+                color: var(--primary-foreground-color);
+
+                .release-info {
+                    font-size: 0.85rem;
+                    font-weight: 600;
+                    opacity: 0.9;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+
+                .imdb-rating {
+                    display: flex;
+                    flex-direction: row;
+                    align-items: center;
+                    font-size: 0.85rem;
+                    font-weight: 700;
+                    color: var(--color-imdb);
+                    white-space: nowrap;
+                    flex-shrink: 0;
+                    margin-left: 0.25rem;
+
+                    .imdb-icon {
+                        width: 1.8rem;
+                        height: 0.9rem;
+                        margin-right: 0.2rem;
+                    }
+                }
+            }
+        }
+
         .new-videos {
             z-index: -1;
             position: absolute;
@@ -318,6 +383,7 @@
             color: var(--primary-foreground-color);
             display: -webkit-box;
             -webkit-line-clamp: 2;
+            line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;
 


### PR DESCRIPTION
### What changed
This PR adds the release year and IMDb rating to the `MetaItem` hover state across the application (Board, Discover, etc.). 

### Why it changed
Currently, users have to click into a poster to see basic information like the release year or its IMDb score. Adding this data to the hover overlay makes the browsing experience faster, more informative, and gives the UI a more premium, tactile feel similar to other modern streaming platforms. 

### How it was verified
- Extracted `releaseInfo` and parsed the `imdb` category from the `links` prop in `MetaItem.js`.
- Added a `.info-layer` in `styles.less` with a smooth slide-up animation (`transform: translateY(0)`) and a subtle gradient backdrop to ensure text legibility on bright posters.
- Ensured text doesn't wrap using `white-space: nowrap` and `text-overflow: ellipsis`.
- Ran `pnpm run lint` and verified there are no errors.
- Tested locally across the Discover and Board pages.

These are some videos and images for the enhancement

https://github.com/user-attachments/assets/f1286e72-9009-4f54-b7c3-e1574079411c

BEFORE 
<img width="1026" height="467" alt="image" src="https://github.com/user-attachments/assets/652f7878-72ad-4a3d-aeb8-add4a985a15f" />


AFTER

<img width="867" height="476" alt="Screenshot 2026-08-30 233901" src="https://github.com/user-attachments/assets/07bc5610-3b17-4a46-a87d-ee59271c6990" />

Closes #1403
