### PR TITLE
App: Confirm streaming server URL from search params

### DIFF
--- a/src/App/SearchParamsHandler.js
+++ b/src/App/SearchParamsHandler.js
@@ -4,6 +4,16 @@ const React = require('react');
 const { deepEqual } = require('fast-equals');
 const { useCore } = require('stremio/core');
 const { withCoreSuspender, useProfile, useToast } = require('stremio/common');
+const { default: StreamingServerUrlModal } = require('./StreamingServerUrlModal');
+
+const isValidStreamingServerUrl = (url) => {
+    try {
+        const { protocol } = new URL(url);
+        return protocol === 'http:' || protocol === 'https:';
+    } catch (_) {
+        return false;
+    }
+};
 
 const SearchParamsHandler = () => {
     const core = useCore();
@@ -11,6 +21,7 @@ const SearchParamsHandler = () => {
     const toast = useToast();
 
     const [searchParams, setSearchParams] = React.useState({});
+    const [requestedStreamingServerUrl, setRequestedStreamingServerUrl] = React.useState(null);
 
     const onLocationChange = () => {
         const { origin, hash, search } = window.location;
@@ -22,32 +33,41 @@ const SearchParamsHandler = () => {
         });
     };
 
+    const onStreamingServerUrlConfirm = React.useCallback(() => {
+        core.transport.dispatch({
+            action: 'Ctx',
+            args: {
+                action: 'UpdateSettings',
+                args: {
+                    ...profile.settings,
+                    streamingServerUrl: requestedStreamingServerUrl,
+                },
+            },
+        });
+        core.transport.dispatch({
+            action: 'Ctx',
+            args: {
+                action: 'AddServerUrl',
+                args: requestedStreamingServerUrl,
+            },
+        });
+        toast.show({
+            type: 'success',
+            title: `Using streaming server at ${requestedStreamingServerUrl}`,
+            timeout: 4000,
+        });
+        setRequestedStreamingServerUrl(null);
+    }, [requestedStreamingServerUrl, profile.settings]);
+
+    const onStreamingServerUrlCancel = React.useCallback(() => {
+        setRequestedStreamingServerUrl(null);
+    }, []);
+
     React.useEffect(() => {
         const { streamingServerUrl } = searchParams;
 
-        if (streamingServerUrl) {
-            core.transport.dispatch({
-                action: 'Ctx',
-                args: {
-                    action: 'UpdateSettings',
-                    args: {
-                        ...profile.settings,
-                        streamingServerUrl,
-                    },
-                },
-            });
-            core.transport.dispatch({
-                action: 'Ctx',
-                args: {
-                    action: 'AddServerUrl',
-                    args: streamingServerUrl,
-                },
-            });
-            toast.show({
-                type: 'success',
-                title: `Using streaming server at ${streamingServerUrl}`,
-                timeout: 4000,
-            });
+        if (streamingServerUrl && isValidStreamingServerUrl(streamingServerUrl)) {
+            setRequestedStreamingServerUrl(streamingServerUrl);
         }
     }, [searchParams]);
 
@@ -57,7 +77,14 @@ const SearchParamsHandler = () => {
         return () => window.removeEventListener('hashchange', onLocationChange);
     }, []);
 
-    return null;
+    return requestedStreamingServerUrl !== null ?
+        <StreamingServerUrlModal
+            url={requestedStreamingServerUrl}
+            onConfirm={onStreamingServerUrlConfirm}
+            onCancel={onStreamingServerUrlCancel}
+        />
+        :
+        null;
 };
 
 module.exports = withCoreSuspender(SearchParamsHandler);

--- a/src/App/StreamingServerUrlModal/StreamingServerUrlModal.tsx
+++ b/src/App/StreamingServerUrlModal/StreamingServerUrlModal.tsx
@@ -1,0 +1,58 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { Button } from 'stremio/components';
+import styles from './styles.less';
+
+type Props = {
+    url: string,
+    onConfirm: () => void,
+    onCancel: () => void,
+};
+
+const StreamingServerUrlModal = ({ url, onConfirm, onCancel }: Props) => {
+    const { t } = useTranslation();
+
+    useEffect(() => {
+        const onKeyDown = ({ key }: KeyboardEvent) => {
+            key === 'Escape' && onCancel();
+        };
+
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [onCancel]);
+
+    return createPortal((
+        <div className={styles['streaming-server-url-modal']}>
+            <div className={styles['backdrop']} onClick={onCancel} />
+
+            <div className={styles['container']}>
+                <div className={styles['title']}>
+                    {t('SETTINGS_SERVER_CONFIGURE_TITLE')}
+                </div>
+
+                <div className={styles['message']}>
+                    {t('SETTINGS_SERVER_CONFIGURE_CONFIRM')}
+                </div>
+
+                <div className={styles['url']}>
+                    {url}
+                </div>
+
+                <div className={styles['buttons']}>
+                    <Button className={styles['cancel-button']} title={t('BUTTON_CANCEL')} onClick={onCancel}>
+                        <div className={styles['label']}>{t('BUTTON_CANCEL')}</div>
+                    </Button>
+
+                    <Button className={styles['confirm-button']} title={t('BUTTON_CONFIRM')} onClick={onConfirm}>
+                        <div className={styles['label']}>{t('BUTTON_CONFIRM')}</div>
+                    </Button>
+                </div>
+            </div>
+        </div>
+    ), document.body);
+};
+
+export default StreamingServerUrlModal;

--- a/src/App/StreamingServerUrlModal/index.ts
+++ b/src/App/StreamingServerUrlModal/index.ts
@@ -1,0 +1,5 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+import StreamingServerUrlModal from './StreamingServerUrlModal';
+
+export default StreamingServerUrlModal;

--- a/src/App/StreamingServerUrlModal/styles.less
+++ b/src/App/StreamingServerUrlModal/styles.less
@@ -1,0 +1,96 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+@import (reference) '~@stremio/stremio-colors/less/stremio-colors.less';
+
+.streaming-server-url-modal {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .backdrop {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background-color: @color-background-dark5-40;
+        cursor: pointer;
+    }
+
+    .container {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        max-width: 40rem;
+        padding: 2.5rem;
+        border-radius: var(--border-radius);
+        background-color: var(--modal-background-color);
+        box-shadow: var(--outer-glow);
+
+        .title {
+            font-size: 1.5rem;
+            font-weight: 500;
+            color: var(--primary-foreground-color);
+        }
+
+        .message {
+            font-size: 1rem;
+            color: var(--primary-foreground-color);
+            opacity: 0.8;
+        }
+
+        .url {
+            font-size: 1rem;
+            font-weight: 500;
+            color: var(--primary-foreground-color);
+            direction: ltr;
+            unicode-bidi: isolate-override;
+            overflow-wrap: anywhere;
+        }
+
+        .buttons {
+            display: flex;
+            flex-direction: row;
+            gap: 1rem;
+            margin-top: 1rem;
+
+            .cancel-button, .confirm-button {
+                flex: 1;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                height: 3.5rem;
+                padding: 1.2rem;
+                border-radius: 3.5rem;
+                background-color: var(--secondary-accent-color);
+
+                &:hover {
+                    background-color: transparent;
+                    outline: var(--focus-outline-size) solid var(--secondary-accent-color);
+                }
+
+                &:focus {
+                    outline-color: var(--primary-foreground-color);
+                }
+
+                .label {
+                    color: var(--primary-foreground-color);
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                    overflow: hidden;
+                }
+            }
+
+            .cancel-button {
+                background-color: transparent;
+                outline: var(--focus-outline-size) solid var(--secondary-accent-color);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Problem

`?streamingServerUrl=` is applied as soon as the app sees it, without any validation or user interaction:

```js
// src/App/SearchParamsHandler.js
if (streamingServerUrl) {
    core.transport.dispatch({ action: 'Ctx', args: { action: 'UpdateSettings', args: { ...profile.settings, streamingServerUrl } } });
    core.transport.dispatch({ action: 'Ctx', args: { action: 'AddServerUrl', args: streamingServerUrl } });
}
```

Any page that gets the browser to open a Stremio link can repoint the streaming server of the running app, and the value is not even checked to be an `http(s)` URL. Adding a server from Settings already requires an explicit user action — this was the only path that did not.

### Change

The parameter is now ignored unless it parses as a URL with an `http:` or `https:` scheme, using the same `new URL()` check as `useStreamingServerUrls` plus a scheme allowlist. When it is valid, a dialog shows the URL and `UpdateSettings` / `AddServerUrl` are dispatched only on confirm. Cancel, backdrop click and Escape leave the settings untouched.

The dialog portals into `document.body` like `ShortcutsModal` and `GamepadModal`; `ModalDialog` is not usable here because `SearchParamsHandler` sits outside the per-route `ModalsContainerProvider`. The URL is displayed with `direction: ltr; unicode-bidi: isolate-override` so a bidi override character in the parameter cannot reorder what the user reads.

Needs Stremio/stremio-translations#1104 for `SETTINGS_SERVER_CONFIGURE_CONFIRM`. The title reuses `SETTINGS_SERVER_CONFIGURE_TITLE`, the buttons `BUTTON_CANCEL` and `BUTTON_CONFIRM`.

An invalid parameter is dropped silently rather than raising an error toast, to avoid adding hardcoded text — happy to add a key for it instead.
