### PR TITLE
Keep current settings when selecting a server

### DIFF
--- a/src/common/useSettings.ts
+++ b/src/common/useSettings.ts
@@ -4,11 +4,11 @@ import { useCallback } from 'react';
 import useProfile from './useProfile';
 import { useCore } from 'stremio/core';
 
-const useSettings = (): [Settings, (settings: Settings) => void] => {
+const useSettings = (): [Settings, (settings: Partial<Settings>) => void] => {
     const core = useCore();
     const profile = useProfile();
 
-    const updateSettings = useCallback((settings: Settings) => {
+    const updateSettings = useCallback((settings: Partial<Settings>) => {
         core.transport.dispatch({
             action: 'Ctx',
             args: {
@@ -19,7 +19,7 @@ const useSettings = (): [Settings, (settings: Settings) => void] => {
                 }
             }
         });
-    }, [profile]);
+    }, [profile.settings]);
 
     return [profile.settings, updateSettings];
 };

--- a/src/routes/Settings/Streaming/URLsManager/Item/Item.tsx
+++ b/src/routes/Settings/Streaming/URLsManager/Item/Item.tsx
@@ -27,11 +27,11 @@ const Item = ({ url }: Props) => {
     const handleDelete = useCallback(() => {
         deleteServerUrl(url);
         selected && selectServerUrl(DEFAULT_STREAMING_SERVER_URL);
-    }, [url, selected]);
+    }, [url, selected, deleteServerUrl, selectServerUrl]);
 
     const handleSelect = useCallback(() => {
         selectServerUrl(url);
-    }, [url]);
+    }, [url, selectServerUrl]);
 
     return (
         <div className={styles['item']}>

--- a/src/routes/Settings/Streaming/URLsManager/useStreamingServerUrls.js
+++ b/src/routes/Settings/Streaming/URLsManager/useStreamingServerUrls.js
@@ -2,12 +2,11 @@
 
 import { useCallback } from 'react';
 import { useCore } from 'stremio/core';
-import { useModelState, useToast } from 'stremio/common';
-import useProfile from 'stremio/common/useProfile';
+import { useModelState, useSettings, useToast } from 'stremio/common';
 
 const useStreamingServerUrls = () => {
     const core = useCore();
-    const profile = useProfile();
+    const [, updateSettings] = useSettings();
     const toast = useToast();
     const ctx = useModelState({ model: 'ctx' });
     const streamingServerUrls = ctx.streamingServerUrls;
@@ -57,17 +56,8 @@ const useStreamingServerUrls = () => {
         });
     }, []);
     const selectServerUrl = useCallback((url) => {
-        core.transport.dispatch({
-            action: 'Ctx',
-            args: {
-                action: 'UpdateSettings',
-                args: {
-                    ...profile.settings,
-                    streamingServerUrl: url
-                }
-            }
-        });
-    }, [profile.settings]);
+        updateSettings({ streamingServerUrl: url });
+    }, [updateSettings]);
     const reloadServer = useCallback(() => {
         core.transport.dispatch({
             action: 'StreamingServer',


### PR DESCRIPTION
Selecting a streaming server could write an old settings snapshot. Use the existing settings update hook and keep row handlers tied to current actions.

clean up stack