### PR TITLE
Share server row state and skip equal Core updates

### DIFF
--- a/src/common/useModelState.js
+++ b/src/common/useModelState.js
@@ -17,10 +17,15 @@ const useModelState = ({ action, ...args }) => {
     const { getState } = useCoreSuspender();
     const [state, setState] = React.useReducer(
         (prevState, nextState) => {
-            return Object.keys(prevState).reduce((result, key) => {
-                result[key] = deepEqual(prevState[key], nextState[key]) ? prevState[key] : nextState[key];
+            const keys = Object.keys(nextState);
+            let changed = keys.length !== Object.keys(prevState).length;
+            const state = keys.reduce((result, key) => {
+                const equal = Object.prototype.hasOwnProperty.call(prevState, key) && deepEqual(prevState[key], nextState[key]);
+                changed = changed || !equal;
+                result[key] = equal ? prevState[key] : nextState[key];
                 return result;
             }, {});
+            return changed ? state : prevState;
         },
         undefined,
         () => {

--- a/src/routes/Settings/Streaming/Streaming.tsx
+++ b/src/routes/Settings/Streaming/Streaming.tsx
@@ -39,7 +39,7 @@ const Streaming = forwardRef<HTMLDivElement, Props>(({ profile, streamingServer 
 
     return (
         <Section ref={ref} label={'SETTINGS_NAV_STREAMING'}>
-            <URLsManager />
+            <URLsManager selectedUrl={profile.settings.streamingServerUrl} settings={streamingServer.settings} />
             {
                 streamingServerRemoteUrlInput.value !== null &&
                     <Option className={styles['configure-input-container']} label={'SETTINGS_REMOTE_URL'}>

--- a/src/routes/Settings/Streaming/URLsManager/Item/Item.tsx
+++ b/src/routes/Settings/Streaming/URLsManager/Item/Item.tsx
@@ -1,27 +1,24 @@
 // Copyright (C) 2017-2024 Smart code 203358507
 
 import React, { useCallback, useMemo } from 'react';
-import { useProfile } from 'stremio/common';
 import { DEFAULT_STREAMING_SERVER_URL } from 'stremio/common/CONSTANTS';
 import { useTranslation } from 'react-i18next';
 import { Button, RadioButton } from 'stremio/components';
-import useStreamingServer from 'stremio/common/useStreamingServer';
 import Icon from '@stremio/stremio-icons/react';
 import styles from './Item.less';
 import classNames from 'classnames';
-import useStreamingServerUrls from '../useStreamingServerUrls';
 
 type Props = {
     url: string;
+    selected: boolean;
+    settings: StreamingServer['settings'];
+    deleteServerUrl: (url: string) => void;
+    selectServerUrl: (url: string) => void;
 };
 
-const Item = ({ url }: Props) => {
+const Item = ({ url, selected, settings, deleteServerUrl, selectServerUrl }: Props) => {
     const { t } = useTranslation();
-    const profile = useProfile();
-    const streamingServer = useStreamingServer();
-    const { deleteServerUrl, selectServerUrl } = useStreamingServerUrls();
 
-    const selected = useMemo(() => profile.settings.streamingServerUrl === url, [url, profile.settings]);
     const defaultUrl = useMemo(() => url === DEFAULT_STREAMING_SERVER_URL, [url]);
 
     const handleDelete = useCallback(() => {
@@ -43,19 +40,19 @@ const Item = ({ url }: Props) => {
                 {
                     selected ?
                         <div className={styles['status']}>
-                            <div className={classNames(styles['icon'], { [styles['ready']]: streamingServer.settings?.type === 'Ready' }, { [styles['error']]: streamingServer.settings?.type === 'Err' })} />
+                            <div className={classNames(styles['icon'], { [styles['ready']]: settings?.type === 'Ready' }, { [styles['error']]: settings?.type === 'Err' })} />
                             <div className={styles['label']}>
                                 {
-                                    streamingServer.settings === null ?
+                                    settings === null ?
                                         'NotLoaded'
                                         :
-                                        streamingServer.settings.type === 'Ready' ?
+                                        settings.type === 'Ready' ?
                                             t('SETTINGS_SERVER_STATUS_ONLINE')
                                             :
-                                            streamingServer.settings.type === 'Err' ?
+                                            settings.type === 'Err' ?
                                                 t('SETTINGS_SERVER_STATUS_ERROR')
                                                 :
-                                                streamingServer.settings.type
+                                                settings.type
                                 }
                             </div>
                         </div>

--- a/src/routes/Settings/Streaming/URLsManager/URLsManager.tsx
+++ b/src/routes/Settings/Streaming/URLsManager/URLsManager.tsx
@@ -9,10 +9,15 @@ import AddItem from './AddItem';
 import Icon from '@stremio/stremio-icons/react';
 import useStreamingServerUrls from './useStreamingServerUrls';
 
-const URLsManager = () => {
+type Props = {
+    selectedUrl: string;
+    settings: StreamingServer['settings'];
+};
+
+const URLsManager = ({ selectedUrl, settings }: Props) => {
     const { t } = useTranslation();
     const [addMode, setAddMode] = useState(false);
-    const { streamingServerUrls, addServerUrl, reloadServer } = useStreamingServerUrls();
+    const { streamingServerUrls, addServerUrl, deleteServerUrl, selectServerUrl, reloadServer } = useStreamingServerUrls();
 
     const onAdd = () => {
         setAddMode(true);
@@ -36,7 +41,14 @@ const URLsManager = () => {
             <div className={styles['content']}>
                 {
                     streamingServerUrls.map((item: StreamingServerUrl) => (
-                        <Item key={item.url} {...item} />
+                        <Item
+                            key={item.url}
+                            url={item.url}
+                            selected={item.url === selectedUrl}
+                            settings={settings}
+                            deleteServerUrl={deleteServerUrl}
+                            selectServerUrl={selectServerUrl}
+                        />
                     ))
                 }
                 {


### PR DESCRIPTION
Every server row subscribed to the same Core models. Pass state and actions from the existing owner, and preserve model state identity when selected data is equal.