### PR TITLE
Cancel obsolete social login attempts

### DIFF
--- a/src/routes/Intro/Intro.js
+++ b/src/routes/Intro/Intro.js
@@ -107,11 +107,7 @@ const Intro = () => {
                 closeLoaderModal();
                 dispatch({ type: 'error', error: error.message });
             });
-    }, []);
-    const cancelLoginWithFacebook = React.useCallback(() => {
-        stopFacebookLogin();
-        closeLoaderModal();
-    }, []);
+    }, [startFacebookLogin, openLoaderModal, closeLoaderModal]);
     const loginWithApple = React.useCallback(() => {
         openLoaderModal();
         startAppleLogin()
@@ -134,11 +130,12 @@ const Intro = () => {
                 closeLoaderModal();
                 dispatch({ type: 'error', error: error.message });
             });
-    }, []);
-    const cancelLoginWithApple = React.useCallback(() => {
+    }, [startAppleLogin, openLoaderModal, closeLoaderModal]);
+    const cancelSocialLogin = React.useCallback(() => {
+        stopFacebookLogin();
         stopAppleLogin();
         closeLoaderModal();
-    }, []);
+    }, [stopFacebookLogin, stopAppleLogin, closeLoaderModal]);
     const loginWithEmail = React.useCallback(() => {
         if (typeof state.email !== 'string' || state.email.length === 0 || !emailRef.current.validity.valid) {
             dispatch({ type: 'error', error: t('INVALID_EMAIL') });
@@ -422,7 +419,7 @@ const Intro = () => {
                         <div className={styles['loader-container']}>
                             <Icon className={styles['icon']} name={'person'} />
                             <div className={styles['label']}>{t('AUTHENTICATING')}</div>
-                            <Button className={styles['button']} onClick={cancelLoginWithFacebook && cancelLoginWithApple}>
+                            <Button className={styles['button']} onClick={cancelSocialLogin}>
                                 {t('BUTTON_CANCEL')}
                             </Button>
                         </div>

--- a/src/routes/Intro/useAppleLogin.ts
+++ b/src/routes/Intro/useAppleLogin.ts
@@ -1,8 +1,6 @@
 // Copyright (C) 2017-2025 Smart code 203358507
 
-import { useCallback, useEffect, useRef } from 'react';
-import { usePlatform } from 'stremio/common';
-import hat from 'hat';
+import useSocialLogin from './useSocialLogin';
 
 type AppleLoginResponse = {
     token: string;
@@ -12,7 +10,6 @@ type AppleLoginResponse = {
 };
 
 const STREMIO_URL = 'https://www.strem.io';
-const MAX_TRIES = 25;
 
 const getCredentials = async (state: string): Promise<AppleLoginResponse> => {
     try {
@@ -33,49 +30,12 @@ const getCredentials = async (state: string): Promise<AppleLoginResponse> => {
 };
 
 const useAppleLogin = (): [() => Promise<AppleLoginResponse>, () => void] => {
-    const platform = usePlatform();
-    const started = useRef(false);
-    const timeout = useRef<NodeJS.Timeout | null>(null);
-
-    const start = useCallback(() => new Promise<AppleLoginResponse>((resolve, reject) => {
-        started.current = true;
-        const state = hat(128);
-        let tries = 0;
-
-        platform.openExternal(`${STREMIO_URL}/login-apple/${state}`);
-
-        const waitForCredentials = () => {
-            if (started.current) {
-                timeout.current && clearTimeout(timeout.current);
-                timeout.current = setTimeout(() => {
-                    if (tries >= MAX_TRIES)
-                        return reject(new Error('Failed to authenticate with Apple', { cause: 'Number of allowed tries exceeded!' }));
-
-                    tries++;
-
-                    getCredentials(state)
-                        .then(resolve)
-                        .catch(waitForCredentials);
-                }, 2000);
-            }
-        };
-
-        waitForCredentials();
-    }), []);
-
-    const stop = useCallback(() => {
-        started.current = false;
-        timeout.current && clearTimeout(timeout.current);
-    }, []);
-
-    useEffect(() => {
-        return () => stop();
-    }, []);
-
-    return [
-        start,
-        stop,
-    ];
+    return useSocialLogin({
+        loginUrl: `${STREMIO_URL}/login-apple`,
+        getCredentials,
+        interval: 2000,
+        errorMessage: 'Failed to authenticate with Apple',
+    });
 };
 
 export default useAppleLogin;

--- a/src/routes/Intro/useFacebookLogin.ts
+++ b/src/routes/Intro/useFacebookLogin.ts
@@ -1,11 +1,8 @@
 // Copyright (C) 2017-2023 Smart code 203358507
 
-import { useCallback, useEffect, useRef } from 'react';
-import hat from 'hat';
-import { usePlatform } from 'stremio/common';
+import useSocialLogin from './useSocialLogin';
 
 const STREMIO_URL = 'https://www.strem.io';
-const MAX_TRIES = 25;
 
 const getCredentials = async (state: string) => {
     try {
@@ -23,49 +20,12 @@ const getCredentials = async (state: string) => {
 };
 
 const useFacebookLogin = () => {
-    const platform = usePlatform();
-    const started = useRef(false);
-    const timeout = useRef<NodeJS.Timeout | null>(null);
-
-    const start = useCallback(() => new Promise((resolve, reject) => {
-        started.current = true;
-        const state = hat(128);
-        let tries = 0;
-
-        platform.openExternal(`${STREMIO_URL}/login-fb/${state}`);
-
-        const waitForCredentials = () => {
-            if (started.current) {
-                timeout.current && clearTimeout(timeout.current);
-                timeout.current = setTimeout(() => {
-                    if (tries >= MAX_TRIES)
-                        return reject(new Error('Failed to authenticate with facebook', { cause: 'Number of allowed tries exceeded!' }));
-
-                    tries++;
-
-                    getCredentials(state)
-                        .then(resolve)
-                        .catch(waitForCredentials);
-                }, 1000);
-            }
-        };
-
-        waitForCredentials();
-    }), []);
-
-    const stop = useCallback(() => {
-        started.current = false;
-        timeout.current && clearTimeout(timeout.current);
-    }, []);
-
-    useEffect(() => {
-        return () => stop();
-    }, []);
-
-    return [
-        start,
-        stop,
-    ];
+    return useSocialLogin({
+        loginUrl: `${STREMIO_URL}/login-fb`,
+        getCredentials,
+        interval: 1000,
+        errorMessage: 'Failed to authenticate with facebook',
+    });
 };
 
 module.exports = useFacebookLogin;

--- a/src/routes/Intro/useSocialLogin.ts
+++ b/src/routes/Intro/useSocialLogin.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { usePlatform } from 'stremio/common';
+import hat from 'hat';
+
+type Options<T> = {
+    loginUrl: string;
+    getCredentials: (state: string) => Promise<T>;
+    interval: number;
+    errorMessage: string;
+};
+
+type Attempt = {
+    timeout: ReturnType<typeof setTimeout> | null;
+};
+
+const MAX_TRIES = 25;
+
+const useSocialLogin = <T>({ loginUrl, getCredentials, interval, errorMessage }: Options<T>): [() => Promise<T>, () => void] => {
+    const { openExternal } = usePlatform();
+    const currentAttempt = useRef<Attempt | null>(null);
+
+    const stop = useCallback(() => {
+        const attempt = currentAttempt.current;
+        currentAttempt.current = null;
+        if (attempt?.timeout) {
+            clearTimeout(attempt.timeout);
+        }
+    }, []);
+
+    const start = useCallback(() => {
+        stop();
+        return new Promise<T>((resolve, reject) => {
+            const attempt: Attempt = { timeout: null };
+            currentAttempt.current = attempt;
+            const state = hat(128);
+            let tries = 0;
+
+            openExternal(`${loginUrl}/${state}`);
+
+            const waitForCredentials = () => {
+                if (currentAttempt.current !== attempt) {
+                    return;
+                }
+
+                attempt.timeout = setTimeout(() => {
+                    if (tries >= MAX_TRIES) {
+                        currentAttempt.current = null;
+                        reject(new Error(errorMessage, { cause: 'Number of allowed tries exceeded!' }));
+                        return;
+                    }
+
+                    tries++;
+                    getCredentials(state)
+                        .then((credentials) => {
+                            if (currentAttempt.current === attempt) {
+                                currentAttempt.current = null;
+                                resolve(credentials);
+                            }
+                        })
+                        .catch(waitForCredentials);
+                }, interval);
+            };
+
+            waitForCredentials();
+        });
+    }, [stop, openExternal, loginUrl, getCredentials, interval, errorMessage]);
+
+    useEffect(() => stop, [stop]);
+
+    return [start, stop];
+};
+
+export default useSocialLogin;


### PR DESCRIPTION
Cancelled Apple and Facebook attempts could still authenticate. Share attempt cancellation and make the Intro Cancel action stop both providers.