### PR TITLE
Load visible catalogs by model index and cancel queued measurements

### DIFF
--- a/src/common/useVisibleCatalogs.ts
+++ b/src/common/useVisibleCatalogs.ts
@@ -1,0 +1,47 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
+import getVisibleChildrenRange from './getVisibleChildrenRange';
+import { useRouteActive } from './useRouteFocused';
+
+const debounce: (callback: () => void, wait: number) => { (): void, cancel: () => void } = require('lodash.debounce');
+
+type Props = {
+    catalogs: NonNullable<CatalogsWithExtra['catalogs']>,
+    loadRange: (range: { start: number, end: number }) => void,
+    leadingRows?: number,
+    preloadRows?: number,
+};
+
+const useVisibleCatalogs = ({ catalogs, loadRange, leadingRows = 0, preloadRows = 0 }: Props) => {
+    const active = useRouteActive();
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+    const catalogRows = useMemo(() => catalogs
+        .map((catalog, index) => ({ catalog, index }))
+        .filter(({ catalog }) => catalog.content?.type !== 'Err' || catalog.content.content !== 'EmptyContent'), [catalogs]);
+
+    const measure = useCallback(() => {
+        if (!active || !scrollContainerRef.current || catalogRows.length === 0) return;
+
+        const range = getVisibleChildrenRange(scrollContainerRef.current);
+        if (range === null) return;
+
+        const firstRow = catalogRows[Math.max(0, range.start - leadingRows)];
+        const lastIndex = range.end - leadingRows;
+        const lastRowIndex = lastIndex < 0 ? firstRow.index - 1 : catalogRows[lastIndex].index;
+        const start = Math.max(0, firstRow.index - preloadRows);
+        const end = Math.min(catalogs.length - 1, lastRowIndex + preloadRows);
+        if (end >= start) loadRange({ start, end });
+    }, [active, catalogRows, catalogs.length, leadingRows, preloadRows, loadRange]);
+
+    const onScroll = useMemo(() => debounce(measure, 250), [measure]);
+
+    useLayoutEffect(() => {
+        measure();
+        return () => onScroll.cancel();
+    }, [measure, onScroll]);
+
+    return { catalogRows, scrollContainerRef, onScroll };
+};
+
+export default useVisibleCatalogs;

--- a/src/common/useVisibleCatalogs.ts
+++ b/src/common/useVisibleCatalogs.ts
@@ -26,8 +26,9 @@ const useVisibleCatalogs = ({ catalogs, loadRange, leadingRows = 0, preloadRows 
         const range = getVisibleChildrenRange(scrollContainerRef.current);
         if (range === null) return;
 
-        const firstRow = catalogRows[Math.max(0, range.start - leadingRows)];
-        const lastIndex = range.end - leadingRows;
+        const maxRow = catalogRows.length - 1;
+        const firstRow = catalogRows[Math.min(maxRow, Math.max(0, range.start - leadingRows))];
+        const lastIndex = Math.min(maxRow, range.end - leadingRows);
         const lastRowIndex = lastIndex < 0 ? firstRow.index - 1 : catalogRows[lastIndex].index;
         const start = Math.max(0, firstRow.index - preloadRows);
         const end = Math.min(catalogs.length - 1, lastRowIndex + preloadRows);

--- a/src/routes/Board/Board.js
+++ b/src/routes/Board/Board.js
@@ -2,9 +2,9 @@
 
 const React = require('react');
 const classnames = require('classnames');
-const debounce = require('lodash.debounce');
 const useTranslate = require('stremio/common/useTranslate');
-const { useStreamingServer, useNotifications, withCoreSuspender, getVisibleChildrenRange, useProfile } = require('stremio/common');
+const { default: useVisibleCatalogs } = require('stremio/common/useVisibleCatalogs');
+const { useStreamingServer, useNotifications, withCoreSuspender, useProfile } = require('stremio/common');
 const { ContinueWatchingItem, EventModal, MainNavBars, MetaItem, MetaRow } = require('stremio/components');
 const useBoard = require('./useBoard');
 const useContinueWatchingPreview = require('./useContinueWatchingPreview');
@@ -21,30 +21,17 @@ const Board = () => {
     const notifications = useNotifications();
     const profile = useProfile();
     const boardCatalogsOffset = continueWatchingPreview.items.length > 0 ? 1 : 0;
-    const scrollContainerRef = React.useRef();
     const showStreamingServerWarning = React.useMemo(() => {
         return streamingServer.settings !== null && streamingServer.settings.type === 'Err' && (
             isNaN(profile.settings.streamingServerWarningDismissed.getTime()) ||
             profile.settings.streamingServerWarningDismissed.getTime() < Date.now());
     }, [profile.settings, streamingServer.settings]);
-    const onVisibleRangeChange = React.useCallback(() => {
-        const range = getVisibleChildrenRange(scrollContainerRef.current);
-        if (range === null) {
-            return;
-        }
-
-        const start = Math.max(0, range.start - boardCatalogsOffset - THRESHOLD);
-        const end = range.end - boardCatalogsOffset + THRESHOLD;
-        if (end < start) {
-            return;
-        }
-
-        loadBoardRows({ start, end });
-    }, [boardCatalogsOffset]);
-    const onScroll = React.useCallback(debounce(onVisibleRangeChange, 250), [onVisibleRangeChange]);
-    React.useLayoutEffect(() => {
-        onVisibleRangeChange();
-    }, [board.catalogs, onVisibleRangeChange]);
+    const { catalogRows, scrollContainerRef, onScroll } = useVisibleCatalogs({
+        catalogs: board.catalogs,
+        loadRange: loadBoardRows,
+        leadingRows: boardCatalogsOffset,
+        preloadRows: THRESHOLD,
+    });
     return (
         <div className={styles['board-container']}>
             <EventModal />
@@ -62,7 +49,7 @@ const Board = () => {
                             :
                             null
                     }
-                    {board.catalogs.map((catalog, index) => {
+                    {catalogRows.map(({ catalog, index }) => {
                         switch (catalog.content?.type) {
                             case 'Ready': {
                                 return (

--- a/src/routes/Search/Search.js
+++ b/src/routes/Search/Search.js
@@ -2,16 +2,14 @@
 
 const React = require('react');
 const classnames = require('classnames');
-const debounce = require('lodash.debounce');
 const useTranslate = require('stremio/common/useTranslate');
+const { default: useVisibleCatalogs } = require('stremio/common/useVisibleCatalogs');
 const { default: Icon } = require('@stremio/stremio-icons/react');
-const { withCoreSuspender, getVisibleChildrenRange } = require('stremio/common');
+const { withCoreSuspender } = require('stremio/common');
 const { Image, MainNavBars, MetaItem, MetaRow } = require('stremio/components');
 const useSearch = require('./useSearch');
 const styles = require('./styles');
 const { useSearchParams } = require('react-router-dom');
-
-const THRESHOLD = 100;
 
 const Search = () => {
     const [queryParams] = useSearchParams();
@@ -29,23 +27,10 @@ const Search = () => {
             :
             null;
     }, [search.selected]);
-    const scrollContainerRef = React.useRef();
-    const onVisibleRangeChange = React.useCallback(() => {
-        if (search.catalogs.length === 0) {
-            return;
-        }
-
-        const range = getVisibleChildrenRange(scrollContainerRef.current, THRESHOLD);
-        if (range === null) {
-            return;
-        }
-
-        loadSearchRows(range);
-    }, [search.catalogs]);
-    const onScroll = React.useCallback(debounce(onVisibleRangeChange, 250), [onVisibleRangeChange]);
-    React.useLayoutEffect(() => {
-        onVisibleRangeChange();
-    }, [search.catalogs, onVisibleRangeChange]);
+    const { catalogRows, scrollContainerRef, onScroll } = useVisibleCatalogs({
+        catalogs: search.catalogs,
+        loadRange: loadSearchRows,
+    });
     return (
         <MainNavBars className={styles['search-container']} route={'search'} query={query}>
             <div ref={scrollContainerRef} className={styles['search-content']} onScroll={onScroll}>
@@ -85,7 +70,7 @@ const Search = () => {
                                 <div className={styles['message-label']}>{ t.string('STREMIO_TV_SEARCH_NO_ADDONS') }</div>
                             </div>
                             :
-                            search.catalogs.map((catalog, index) => {
+                            catalogRows.map(({ catalog, index }) => {
                                 switch (catalog.content?.type) {
                                     case 'Ready': {
                                         return (


### PR DESCRIPTION
Search and Board used filtered DOM positions as model indexes and left queued measurements alive. Share row mapping and debounce ownership while preserving route activity and Board preload.