### PR TITLE
Keep multiselect outside click handler stable

### DIFF
--- a/src/components/MultiselectMenu/MultiselectMenu.tsx
+++ b/src/components/MultiselectMenu/MultiselectMenu.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 const MultiselectMenu = ({ className, title, options, value, disabled, onSelect }: Props) => {
     const [menuOpen, , closeMenu, toggleMenu] = useBinaryState(false);
-    const multiselectMenuRef = useOutsideClick(() => closeMenu());
+    const multiselectMenuRef = useOutsideClick(closeMenu);
     const [level, setLevel] = React.useState<number>(0);
 
     const selectedOption = options.find((opt) => opt.value === value);


### PR DESCRIPTION
Multiselect recreated its outside-click listener on each render. Pass the existing stable close action directly.