### PR TITLE
Reset image failure state at the source boundary

### DIFF
--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,6 +1,6 @@
 // Copyright (C) 2017-2023 Smart code 203358507
 
-import React, { useCallback, useLayoutEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 type Props = {
     className: string,
@@ -11,7 +11,7 @@ type Props = {
     onError: (event: React.SyntheticEvent<HTMLImageElement>) => void,
 };
 
-const Image = ({ className, src, alt, fallbackSrc, renderFallback, ...props }: Props) => {
+const ImageContent = ({ className, src, alt, fallbackSrc, renderFallback, ...props }: Props) => {
     const [broken, setBroken] = useState(false);
     const onError = useCallback((event: React.SyntheticEvent<HTMLImageElement>) => {
         if (typeof props.onError === 'function') {
@@ -21,10 +21,6 @@ const Image = ({ className, src, alt, fallbackSrc, renderFallback, ...props }: P
         setBroken(true);
     }, [props.onError]);
 
-    useLayoutEffect(() => {
-        setBroken(false);
-    }, [src]);
-
     return (broken || typeof src !== 'string' || src.length === 0) && (typeof renderFallback === 'function' || typeof fallbackSrc === 'string') ?
         typeof renderFallback === 'function' ?
             renderFallback()
@@ -33,5 +29,7 @@ const Image = ({ className, src, alt, fallbackSrc, renderFallback, ...props }: P
         :
         <img {...props} className={className} src={src} alt={alt} loading='lazy' onError={onError} />;
 };
+
+const Image = (props: Props) => <ImageContent key={props.src} {...props} />;
 
 export default Image;

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -2,13 +2,13 @@
 
 import React, { useCallback, useState } from 'react';
 
-type Props = {
-    className: string,
-    src: string,
-    alt: string,
-    fallbackSrc: string,
-    renderFallback: () => React.ReactNode,
-    onError: (event: React.SyntheticEvent<HTMLImageElement>) => void,
+type Props = React.ImgHTMLAttributes<HTMLImageElement> & {
+    className?: string,
+    src?: string,
+    alt?: string,
+    fallbackSrc?: string,
+    renderFallback?: () => React.ReactNode,
+    onError?: (event: React.SyntheticEvent<HTMLImageElement>) => void,
 };
 
 const ImageContent = ({ className, src, alt, fallbackSrc, renderFallback, ...props }: Props) => {


### PR DESCRIPTION
Image reset failure state through a layout effect after a source change. Reset the inner image owner at the source boundary, preserving fallback and retry behavior.