### PR TITLE
Give file drop listeners explicit subscription ownership

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -7,7 +7,7 @@ const { useNavigate } = require('react-router');
 const { useCore } = require('stremio/core');
 const { Routes } = require('stremio-router');
 const { Chromecast, ServicesProvider, GamepadProvider } = require('stremio/services');
-const { FullscreenProvider, ToastProvider, TooltipProvider, ShortcutsProvider, DiscordProvider, CONSTANTS, useBinaryState, useProfile, withCoreSuspender, onFileDrop, usePlatform } = require('stremio/common');
+const { FullscreenProvider, ToastProvider, TooltipProvider, ShortcutsProvider, DiscordProvider, CONSTANTS, useBinaryState, useProfile, withCoreSuspender, useFileDropListener, usePlatform } = require('stremio/common');
 const ServicesToaster = require('./ServicesToaster');
 const SearchParamsHandler = require('./SearchParamsHandler');
 const DeepLinkHandler = require('./DeepLinkHandler');
@@ -18,6 +18,7 @@ const styles = require('./styles');
 
 const ProtectedRoutes = withCoreSuspender(Routes);
 const NAVIGATE_TABS_ROUTES = ['/', '/discover', '/library', '/calendar', '/addons', '/settings'];
+const TORRENT_FILE_TYPES = ['application/x-bittorrent'];
 
 const App = () => {
     const core = useCore();
@@ -57,7 +58,7 @@ const App = () => {
         }
     }, [toggleShortcutModal, toggleGamepadModal]);
 
-    onFileDrop(['application/x-bittorrent'], (file, buffer) => {
+    const onTorrentDrop = React.useCallback((file, buffer) => {
         core.transport.dispatch({
             action: 'StreamingServer',
             args: {
@@ -65,7 +66,9 @@ const App = () => {
                 args: Array.from(new Uint8Array(buffer))
             }
         });
-    });
+    }, []);
+
+    useFileDropListener(TORRENT_FILE_TYPES, onTorrentDrop);
 
     React.useEffect(() => {
         let prevPath = window.location.hash.slice(1);

--- a/src/common/FileDrop/FileDrop.tsx
+++ b/src/common/FileDrop/FileDrop.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, createContext, useContext, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { isFileType, isFileTypeSupported } from './utils';
 import styles from './styles.less';
@@ -21,13 +21,15 @@ const FileDropProvider = ({ children }: Props) => {
     const listeners = useRef<[FileType, FileDropListener][]>([]);
     const [active, setActive] = useState(false);
 
-    const on = (type: FileType, listener: FileDropListener) => {
+    const on = useCallback((type: FileType, listener: FileDropListener) => {
         listeners.current = [...listeners.current, [type, listener]];
-    };
+    }, []);
 
-    const off = (type: FileType, listener: FileDropListener) => {
-        listeners.current = listeners.current.filter(([key, value]) => key !== type && value !== listener);
-    };
+    const off = useCallback((type: FileType, listener: FileDropListener) => {
+        listeners.current = listeners.current.filter(([key, value]) => key !== type || value !== listener);
+    }, []);
+
+    const value = useMemo(() => ({ on, off }), [on, off]);
 
     const onChange = (event: ChangeEvent) => {
         event.preventDefault();
@@ -81,7 +83,7 @@ const FileDropProvider = ({ children }: Props) => {
     }, []);
 
     return (
-        <FileDropContext.Provider value={{ on, off }}>
+        <FileDropContext.Provider value={value}>
             { children }
             <div className={classNames(styles['file-drop-container'], { 'active': active })}>
                 <input type={'file'} className={styles['file-input']} onChange={onChange} />

--- a/src/common/FileDrop/index.ts
+++ b/src/common/FileDrop/index.ts
@@ -1,8 +1,8 @@
 import { FileDropProvider, useFileDrop } from './FileDrop';
-import onFileDrop from './onFileDrop';
+import useFileDropListener from './useFileDropListener';
 
 export {
     FileDropProvider,
     useFileDrop,
-    onFileDrop,
+    useFileDropListener,
 };

--- a/src/common/FileDrop/useFileDropListener.ts
+++ b/src/common/FileDrop/useFileDropListener.ts
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
 import { type FileType, type FileDropListener, useFileDrop } from './FileDrop';
 
-const onFileDrop = (types: FileType[], listener: FileDropListener) => {
+const useFileDropListener = (types: readonly FileType[], listener: FileDropListener) => {
     const { on, off } = useFileDrop();
 
     useEffect(() => {
         types.forEach((type) => on(type, listener));
         return () => types.forEach((type) => off(type, listener));
-    }, []);
+    }, [types, listener, on, off]);
 };
 
-export default onFileDrop;
+export default useFileDropListener;

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -1,6 +1,6 @@
 // Copyright (C) 2017-2023 Smart code 203358507
 
-const { FileDropProvider, useFileDrop, onFileDrop } = require('./FileDrop');
+const { FileDropProvider, useFileDrop, useFileDropListener } = require('./FileDrop');
 const { FullscreenProvider, useFullscreen } = require('./Fullscreen');
 const { PlatformProvider, usePlatform } = require('./Platform');
 const { ToastProvider, useToast } = require('./Toast');
@@ -35,7 +35,7 @@ const { default: useLanguageSorting } = require('./useLanguageSorting');
 module.exports = {
     FileDropProvider,
     useFileDrop,
-    onFileDrop,
+    useFileDropListener,
     FullscreenProvider,
     PlatformProvider,
     usePlatform,

--- a/src/routes/Player/useSubtitles.ts
+++ b/src/routes/Player/useSubtitles.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CONSTANTS, languages, onFileDrop, onShortcut, useToast } from 'stremio/common';
+import { CONSTANTS, languages, useFileDropListener, onShortcut, useToast } from 'stremio/common';
 import { snapSubtitleDelay, SUBTITLES_DELAY_STEP_MS } from './subtitleDelay';
 
 const withFallbackLabels = (tracks?: SubtitleTrack[] | null): SubtitleTrack[] => {
@@ -321,9 +321,11 @@ const useSubtitles = ({
         streamStateChanged({ subtitleOffset: offset });
     }, [streamStateChanged, setSubtitlesOffset]);
 
-    onFileDrop(CONSTANTS.SUPPORTED_LOCAL_SUBTITLES, (file: File, buffer: ArrayBuffer) => {
+    const onSubtitlesDrop = useCallback((file: File, buffer: ArrayBuffer) => {
         videoRef.current.addLocalSubtitles(file.name, buffer);
-    });
+    }, []);
+
+    useFileDropListener(CONSTANTS.SUPPORTED_LOCAL_SUBTITLES, onSubtitlesDrop);
 
     useEffect(() => {
         if (video.state.stream !== null) {


### PR DESCRIPTION
File drop subscriptions captured their first listener and cleanup removed unrelated listeners. Use an explicit subscription hook and remove only the matching type/listener pair.