### PR TITLE
Add Latin American Spanish to language settings

### DIFF
--- a/src/common/languageNames.json
+++ b/src/common/languageNames.json
@@ -149,6 +149,7 @@
     "som": "Soomaaliga",
     "sot": "Sesotho",
     "spa": "Español",
+    "spl": "Español (América Latina)",
     "sun": "Basa Sunda",
     "swa": "Kiswahili",
     "ssw": "SiSwati",


### PR DESCRIPTION
Adds Español (América Latina) (`spl`) to the language settings list used for default subtitles and audio.


Closes Stremio/stremio-bugs#2727
