### PR TITLE
Scrubber thumbnails

### DIFF
--- a/src/routes/Player/ControlBar/ControlBar.js
+++ b/src/routes/Player/ControlBar/ControlBar.js
@@ -137,6 +137,7 @@ const ControlBar = React.forwardRef(({
                 buffered={buffered}
                 onSeekRequested={onSeekRequested}
                 playbackSpeed={playbackSpeed}
+                thumbnailsUrl={stream?.thumbnails}
             />
             <div className={styles['control-bar-buttons-container']}>
                 <Button className={classnames(styles['control-bar-button'], { 'disabled': typeof paused !== 'boolean' })} title={paused ? t('PLAYER_PLAY') : t('PLAYER_PAUSE')} tabIndex={-1} onClick={onPlayPauseButtonClick}>

--- a/src/routes/Player/ControlBar/SeekBar/SeekBar.js
+++ b/src/routes/Player/ControlBar/SeekBar/SeekBar.js
@@ -9,14 +9,17 @@ const { default: useRouteFocused } = require('stremio/common/useRouteFocused');
 const { useBinaryState } = require('stremio/common');
 const { Button, Slider } = require('stremio/components');
 const formatTime = require('./formatTime');
+const useThumbnailCues = require('./useThumbnailCues').default;
+const { findThumbnailCue } = require('./parseThumbnailVtt');
 const styles = require('./styles');
 
-const SeekBar = ({ className, time, duration, buffered, onSeekRequested, playbackSpeed }) => {
+const SeekBar = ({ className, time, duration, buffered, onSeekRequested, playbackSpeed, thumbnailsUrl }) => {
     const disabled = time === null || isNaN(time) || duration === null || isNaN(duration);
     const routeFocused = useRouteFocused();
     const sliderRef = React.useRef(null);
     const [seekTime, setSeekTime] = React.useState(null);
     const [hover, setHover] = React.useState(null);
+    const { cues } = useThumbnailCues(thumbnailsUrl);
 
     const [remainingTimeMode,,, toggleRemainingTimeMode] = useBinaryState(false);
     const resetTimeDebounced = React.useCallback(debounce(() => {
@@ -81,6 +84,22 @@ const SeekBar = ({ className, time, duration, buffered, onSeekRequested, playbac
                     hover !== null && seekTime === null && !disabled ?
                         ReactDOM.createPortal(
                             <div className={styles['seek-tooltip']} style={{ left: `${hover.x}px`, top: `${hover.y}px` }}>
+                                {
+                                    (() => {
+                                        const cue = findThumbnailCue(cues, hover.time);
+                                        return cue ? (
+                                            <div
+                                                className={styles['thumbnail-crop']}
+                                                style={{
+                                                    backgroundImage: `url(${cue.url})`,
+                                                    backgroundPosition: `-${cue.x}px -${cue.y}px`,
+                                                    width: cue.w,
+                                                    height: cue.h
+                                                }}
+                                            />
+                                        ) : null;
+                                    })()
+                                }
                                 {formatTime(hover.time)}
                             </div>,
                             document.body
@@ -106,7 +125,8 @@ SeekBar.propTypes = {
     duration: PropTypes.number,
     buffered: PropTypes.number,
     onSeekRequested: PropTypes.func,
-    playbackSpeed: PropTypes.number
+    playbackSpeed: PropTypes.number,
+    thumbnailsUrl: PropTypes.string
 };
 
 module.exports = SeekBar;

--- a/src/routes/Player/ControlBar/SeekBar/SeekBar.js
+++ b/src/routes/Player/ControlBar/SeekBar/SeekBar.js
@@ -86,18 +86,22 @@ const SeekBar = ({ className, time, duration, buffered, onSeekRequested, playbac
                             <div className={styles['seek-tooltip']} style={{ left: `${hover.x}px`, top: `${hover.y}px` }}>
                                 {
                                     (() => {
-                                        const cue = findThumbnailCue(cues, hover.time);
-                                        return cue ? (
+                                        const cue = findThumbnailCue(cues, hover.time / 1000);
+                                        if (!cue) {
+                                            return null;
+                                        }
+                                        const spriteUrl = new URL(cue.url, thumbnailsUrl).href;
+                                        return (
                                             <div
                                                 className={styles['thumbnail-crop']}
                                                 style={{
-                                                    backgroundImage: `url(${cue.url})`,
+                                                    backgroundImage: `url(${spriteUrl})`,
                                                     backgroundPosition: `-${cue.x}px -${cue.y}px`,
                                                     width: cue.w,
                                                     height: cue.h
                                                 }}
                                             />
-                                        ) : null;
+                                        );
                                     })()
                                 }
                                 {formatTime(hover.time)}

--- a/src/routes/Player/ControlBar/SeekBar/parseThumbnailVtt.ts
+++ b/src/routes/Player/ControlBar/SeekBar/parseThumbnailVtt.ts
@@ -1,0 +1,96 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+export type ThumbnailCue = {
+    start: number,
+    end: number,
+    url: string,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+};
+
+function parseVttTimestamp(t: string): number {
+    const segments = t.trim().split(':').map((s) => parseFloat(s.trim()));
+    if (segments.length < 2 || segments.some((n) => Number.isNaN(n))) {
+        return 0;
+    }
+    const [a, b, c = 0] = segments;
+    return segments.length === 2 ? a * 60 + b : a * 3600 + b * 60 + c;
+}
+
+function parseThumbnailVtt(text: string): ThumbnailCue[] {
+    const cues: ThumbnailCue[] = [];
+    const normalized = text.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    const blocks = normalized.split(/\n\n+/);
+
+    for (const raw of blocks) {
+        const block = raw.trim();
+        if (block.length === 0 || block === 'WEBVTT' || block.startsWith('WEBVTT\n') || block.startsWith('NOTE')) {
+            continue;
+        }
+        const lines = block.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+        if (lines.length < 2) {
+            continue;
+        }
+        let i = 0;
+        if (!lines[0].includes('-->')) {
+            if (lines[1].includes('-->')) {
+                i = 1;
+            } else {
+                continue;
+            }
+        }
+        const timeLine = lines[i];
+        const arrow = timeLine.indexOf('-->');
+        if (arrow === -1) {
+            continue;
+        }
+        const startStr = timeLine.slice(0, arrow).trim();
+        const endStr = timeLine.slice(arrow + 3).trim().split(/\s/)[0];
+        const start = parseVttTimestamp(startStr);
+        const end = parseVttTimestamp(endStr);
+        const imageLine = lines.slice(i + 1).join('\n').trim();
+        if (!imageLine.length) {
+            continue;
+        }
+        const xywhMatch = imageLine.match(/#xywh=(\d+),(\d+),(\d+),(\d+)/);
+        let url = imageLine;
+        let x = 0;
+        let y = 0;
+        let w = 0;
+        let h = 0;
+        if (xywhMatch) {
+            url = imageLine.slice(0, imageLine.indexOf('#'));
+            x = parseInt(xywhMatch[1], 10);
+            y = parseInt(xywhMatch[2], 10);
+            w = parseInt(xywhMatch[3], 10);
+            h = parseInt(xywhMatch[4], 10);
+        }
+        cues.push({ start, end, url, x, y, w, h });
+    }
+
+    cues.sort((a, b) => a.start - b.start);
+    return cues;
+}
+
+function findThumbnailCue(cues: ThumbnailCue[], time: number): ThumbnailCue | null {
+    if (cues.length === 0) {
+        return null;
+    }
+    for (const c of cues) {
+        if (time >= c.start && time < c.end) {
+            return c;
+        }
+    }
+    if (time < cues[0].start) {
+        return cues[0];
+    }
+    const last = cues[cues.length - 1];
+    if (time >= last.end) {
+        return last;
+    }
+    return null;
+}
+
+export { parseThumbnailVtt, findThumbnailCue };

--- a/src/routes/Player/ControlBar/SeekBar/styles.less
+++ b/src/routes/Player/ControlBar/SeekBar/styles.less
@@ -72,6 +72,13 @@
     background-color: var(--modal-background-color);
     box-shadow: 0 0.2rem 0.6rem rgba(0, 0, 0, 0.4);
     pointer-events: none;
+
+    .thumbnail-crop {
+        display: block;
+        margin-bottom: 0.4rem;
+        border-radius: calc(var(--border-radius) - 2px);
+        overflow: hidden;
+    }
 }
 
 @media (hover: none) {

--- a/src/routes/Player/ControlBar/SeekBar/useThumbnailCues.ts
+++ b/src/routes/Player/ControlBar/SeekBar/useThumbnailCues.ts
@@ -1,0 +1,49 @@
+// Copyright (C) 2017-2023 Smart code 203358507
+
+import { useEffect, useState } from 'react';
+import { parseThumbnailVtt, type ThumbnailCue } from './parseThumbnailVtt';
+
+function useThumbnailCues(vttUrl: string | null | undefined): { cues: ThumbnailCue[], error: Error | null } {
+    const [cues, setCues] = useState<ThumbnailCue[]>([]);
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        if (typeof vttUrl !== 'string' || vttUrl.length === 0) {
+            setCues([]);
+            setError(null);
+            return;
+        }
+
+        let cancelled = false;
+        setError(null);
+
+        fetch(vttUrl, { credentials: 'omit' })
+            .then((res) => {
+                if (!res.ok) {
+                    throw new Error(`Thumbnails VTT: ${res.status}`);
+                }
+                return res.text();
+            })
+            .then((text) => {
+                if (cancelled) {
+                    return;
+                }
+                setCues(parseThumbnailVtt(text));
+            })
+            .catch((e: unknown) => {
+                if (cancelled) {
+                    return;
+                }
+                setCues([]);
+                setError(e instanceof Error ? e : new Error(String(e)));
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [vttUrl]);
+
+    return { cues, error };
+}
+
+export default useThumbnailCues;


### PR DESCRIPTION
This PR implements video scrubber thumbnails for Stremio. Plugins can provide VTT files and sprites for live thumbnails.

Closes https://github.com/Stremio/stremio-web/issues/985
Depends on https://github.com/Stremio/stremio-core/pull/1055 for stremio-core

Made a fork of local addon for testing / demo:
https://github.com/warp-records/stremio-local-thumbnails

Demo video:
https://github.com/user-attachments/assets/9d40bd14-9a52-4092-be13-e1656bcb1ee8

Thanks to [mrcanelas](https://github.com/mrcanelas) https://github.com/Stremio/stremio-web/pull/1183 for the VTT parsing logic